### PR TITLE
Move some Renderer code to Engine

### DIFF
--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -14,16 +14,30 @@
 #define ENDGAME 2
 
 
-Engine::Engine() : lastFrame(0.0f)
+Engine::Engine() :
+	deltaSec(0.0f), rotate(0), scale(1),
+	showCursor(false), lastFrame(0.0f)
 {
+	camera = std::make_shared<Camera>();
+	renderer = std::make_unique<Renderer>(camera);
 	loadModels();
+
+	// The following calls require the Renderer to setup GLFW/glad first.
+	glfwSetKeyCallback(renderer->getWindow(), keyCallback);
+	glfwSetCursorPosCallback(renderer->getWindow(), mouseCallback);
+	// tell GLFW to capture our mouse
+	glfwSetInputMode(renderer->getWindow(), GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+
+	// Let GLFW store pointer to this instance of Engine.
+	glfwSetWindowUserPointer(renderer->getWindow(), static_cast<void*>(this));
 }
 
 
 Engine::~Engine() {}
 
 /*
- * Loads all models in rsc/models and stores them in a vector.
+ * Loads all models in rsc/models and stores them in a vector. Requires glad
+ * to have loaded opengl function calls.
 */
 void Engine::loadModels()
 {
@@ -46,21 +60,35 @@ void Engine::loadModels()
 
 void Engine::run()
 {
-	GLFWwindow* window = renderer.getWindow();
 	Simulate simulator;
-	DevUI devUI(renderer.getWindow());
+	DevUI devUI(renderer->getWindow());
 
 	//Controller controller;
 	//renderer.run();
 
-	while (!renderer.isWindowClosed()) {
+	while (!renderer->isWindowClosed()) {
 		// update global time
 		float currentFrame = glfwGetTime();
-		float deltaSec = currentFrame - lastFrame;
+		deltaSec = currentFrame - lastFrame;
 		lastFrame = currentFrame;
 
+		processWindowInput();
+
 		//simulator.stepPhysics();
-		renderer.run(deltaSec, devUI, models);
+		// The following code should be in the Simulator.
+		for (auto& model : models)
+		{
+			model->rotate(rotate);
+			model->scale(scale);
+			model->update();
+		}
+
+		renderer->run(deltaSec, devUI, models);
+
+		rotate = glm::vec3(0.0f);
+		scale = 1;
+
+		glfwPollEvents();
 	}
 
 	//runMenu();
@@ -157,4 +185,144 @@ void Engine::runGame() {
 	}
 
 	//Game loop clean up, before returning to menu
+}
+
+/*
+ * This method typically runs faster than handling a key callback.
+ * So controls like movements should be placed in here.
+ */
+void Engine::processWindowInput()
+{
+	float rotationSpeed = glm::radians(135.0f) * deltaSec;
+	float scaleSpeed = 1.0f + 1.0f * deltaSec;
+	shiftPressed = glfwGetKey(renderer->getWindow(), GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS;
+
+	// Rotations
+	if (!shiftPressed)
+	{
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_W) == GLFW_PRESS)
+		{
+			rotate.x -= rotationSpeed;
+		}
+
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_S) == GLFW_PRESS)
+		{
+			rotate.x += rotationSpeed;
+		}
+
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_E) == GLFW_PRESS)
+		{
+			rotate.y += rotationSpeed;
+		}
+
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_Q) == GLFW_PRESS)
+		{
+			rotate.y -= rotationSpeed;
+		}
+
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_D) == GLFW_PRESS)
+		{
+			rotate.z -= rotationSpeed;
+		}
+
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_A) == GLFW_PRESS)
+		{
+			rotate.z += rotationSpeed;
+		}
+	}
+
+	// Camera Movement
+	if (shiftPressed)
+	{
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_W) == GLFW_PRESS)
+		{
+			camera->processKeyboard(Camera::Movement::FORWARD, deltaSec);
+		}
+
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_S) == GLFW_PRESS)
+		{
+			camera->processKeyboard(Camera::Movement::BACKWARD, deltaSec);
+		}
+
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_D) == GLFW_PRESS)
+		{
+			camera->processKeyboard(Camera::Movement::RIGHT, deltaSec);
+		}
+
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_A) == GLFW_PRESS)
+		{
+			camera->processKeyboard(Camera::Movement::LEFT, deltaSec);
+		}
+
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_E) == GLFW_PRESS)
+		{
+			camera->processKeyboard(Camera::Movement::UP, deltaSec);
+		}
+
+		if (glfwGetKey(renderer->getWindow(), GLFW_KEY_Q) == GLFW_PRESS)
+		{
+			camera->processKeyboard(Camera::Movement::DOWN, deltaSec);
+		}
+	}
+
+	// Scaling
+	if (glfwGetKey(renderer->getWindow(), GLFW_KEY_Z) == GLFW_PRESS)
+	{
+		scale *= scaleSpeed;
+	}
+	if (glfwGetKey(renderer->getWindow(), GLFW_KEY_X) == GLFW_PRESS)
+	{
+		scale /= scaleSpeed;
+	}
+}
+
+/*
+ * Handle keyboard inputs that don't require frequent repeated actions,
+ * ex closing window, selecting model etc.
+ */
+void Engine::keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)
+{
+	Engine* engine = static_cast<Engine*>(glfwGetWindowUserPointer(window));
+
+	if (action == GLFW_PRESS)
+	{
+		switch (key)
+		{
+		case GLFW_KEY_ESCAPE:
+			glfwSetWindowShouldClose(window, true);
+			break;
+
+		case GLFW_KEY_SPACE:
+			if (mods & GLFW_MOD_CONTROL)
+			{
+				engine->showCursor = !engine->showCursor;
+				int cursorMode = engine->showCursor ? GLFW_CURSOR_NORMAL : GLFW_CURSOR_DISABLED;
+				glfwSetInputMode(window, GLFW_CURSOR, cursorMode);
+			}
+			break;
+		}
+	}
+}
+
+void Engine::mouseCallback(GLFWwindow* window, double xpos, double ypos)
+{
+	Engine* engine = static_cast<Engine*>(glfwGetWindowUserPointer(window));
+
+	if (!engine->showCursor)
+	{
+		if (engine->firstMouse)
+		{
+			engine->lastX = xpos;
+			engine->lastY = ypos;
+			engine->firstMouse = false;
+		}
+
+		float xoffset = xpos - engine->lastX;
+		float yoffset = engine->lastY - ypos; // reversed since y-coordinates go from bottom to top
+
+		engine->lastX = xpos;
+		engine->lastY = ypos;
+
+		engine->camera->processMouseMovement(xoffset, yoffset);
+	}
 }

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -16,7 +16,7 @@
 
 Engine::Engine() :
 	deltaSec(0.0f), rotate(0), scale(1),
-	showCursor(false), lastFrame(0.0f)
+	lastFrame(0.0f)
 {
 	camera = std::make_shared<Camera>();
 	renderer = std::make_unique<Renderer>(camera);
@@ -289,15 +289,13 @@ void Engine::keyCallback(GLFWwindow* window, int key, int scancode, int action, 
 		switch (key)
 		{
 		case GLFW_KEY_ESCAPE:
-			glfwSetWindowShouldClose(window, true);
+			engine->renderer->setWindowShouldClose(true);
 			break;
 
 		case GLFW_KEY_SPACE:
 			if (mods & GLFW_MOD_CONTROL)
 			{
-				engine->showCursor = !engine->showCursor;
-				int cursorMode = engine->showCursor ? GLFW_CURSOR_NORMAL : GLFW_CURSOR_DISABLED;
-				glfwSetInputMode(window, GLFW_CURSOR, cursorMode);
+				engine->renderer->toggleCursor();
 			}
 			break;
 		}
@@ -308,7 +306,7 @@ void Engine::mouseCallback(GLFWwindow* window, double xpos, double ypos)
 {
 	Engine* engine = static_cast<Engine*>(glfwGetWindowUserPointer(window));
 
-	if (!engine->showCursor)
+	if (!engine->renderer->isCursorShowing())
 	{
 		if (engine->firstMouse)
 		{

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -83,7 +83,7 @@ void Engine::run()
 			model->update();
 		}
 
-		renderer->run(deltaSec, devUI, models);
+		renderer->render(deltaSec, devUI, models);
 
 		rotate = glm::vec3(0.0f);
 		scale = 1;

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1,5 +1,4 @@
 #include "Engine.h"
-#include "Renderer.h"
 #include "Simulate.h"
 #include "Arena.h"
 #include "Pickup.h"
@@ -8,28 +7,45 @@
 #include "DevUI.h"
 #include "Controller.h"
 
+#include <filesystem>
+
 #define STARTGAME 1
 #define NOINPUT 0
 #define ENDGAME 2
 
-//////////////////////////////////////////////////////////
 
 Engine::Engine() : lastFrame(0.0f)
 {
-
+	loadModels();
 }
 
-//////////////////////////////////////////////////////////
 
-Engine::~Engine() {
+Engine::~Engine() {}
 
+/*
+ * Loads all models in rsc/models and stores them in a vector.
+*/
+void Engine::loadModels()
+{
+	namespace fs = std::filesystem;
+	const std::string extension = ".obj";
+
+	unsigned int count = 1;
+	for (const auto& entry : fs::directory_iterator("rsc/models"))
+	{
+		if (entry.is_regular_file() && entry.path().extension() == extension)
+		{
+			std::cout << "Loading " << entry.path() << "..." << std::flush;
+			models.push_back(std::make_unique<Model>(entry.path().string()));
+			std::cout << "Done! Index: " << count << "\n";
+			count++;
+		}
+	}
 }
 
-//////////////////////////////////////////////////////////
 
-void Engine::run() {
-
-	Renderer renderer;
+void Engine::run()
+{
 	GLFWwindow* window = renderer.getWindow();
 	Simulate simulator;
 	DevUI devUI(renderer.getWindow());
@@ -44,14 +60,13 @@ void Engine::run() {
 		lastFrame = currentFrame;
 
 		//simulator.stepPhysics();
-		renderer.run(deltaSec, devUI);
+		renderer.run(deltaSec, devUI, models);
 	}
 
 	//runMenu();
 	return;
 }
 
-//////////////////////////////////////////////////////////
 
 /*
 This Function contains the loop for the main menu.

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -22,23 +22,33 @@ public:
 	~Engine();
 	void run();
 private:
-	Renderer renderer;
+	std::unique_ptr<Renderer> renderer;
+	float deltaSec;
+
 	Ai aiPlayers[4];
 	Vehicle vehicles[4];
 	Pickup pickups[10];
 
 	std::vector<std::unique_ptr<Model>> models;
+	std::shared_ptr<Camera> camera;
 
-	enum Scene
-	{
-		Test = 0,
-		PhysX = 1,
-	};
+	glm::vec3 rotate;
+	float scale;
+
+	bool shiftPressed;
+	bool showCursor;
+	bool firstMouse;
+	float lastX;
+	float lastY;
 
 	float lastFrame;
 
 	void runMenu();
 	int menuInput();
 	void runGame();
+
 	void loadModels();
+	void processWindowInput();
+	static void keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
+	static void mouseCallback(GLFWwindow* window, double xpos, double ypos);
 };

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -36,7 +36,6 @@ private:
 	float scale;
 
 	bool shiftPressed;
-	bool showCursor;
 	bool firstMouse;
 	float lastX;
 	float lastY;

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -4,13 +4,16 @@
 #include <vector>
 #include <iostream>
 
-#include <string>
 #include <glm/glm.hpp>
+#include <string>
 #include <memory>
+#include <vector>
 
 #include "Ai.h"
 #include "Vehicle.h"
 #include "Pickup.h"
+#include "Model.h"
+#include "Renderer.h"
 
 class Engine
 {
@@ -19,9 +22,12 @@ public:
 	~Engine();
 	void run();
 private:
+	Renderer renderer;
 	Ai aiPlayers[4];
 	Vehicle vehicles[4];
 	Pickup pickups[10];
+
+	std::vector<std::unique_ptr<Model>> models;
 
 	enum Scene
 	{
@@ -34,4 +40,5 @@ private:
 	void runMenu();
 	int menuInput();
 	void runGame();
+	void loadModels();
 };

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -15,11 +15,7 @@ using namespace physx;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-Renderer::Renderer() :
-	modelIndex(0), rotate(0), scale(1),
-	firstMouse(true), lastX(width / 2.0f), lastY(height / 2.0f),
-	shiftPressed(false), deltaSec(0.0f), lastFrame(0.0f), sceneSelect(0),
-	showCursor(false)
+Renderer::Renderer(const std::shared_ptr<Camera> camera) : camera(camera)
 {
 	initWindow();
 	shader = std::make_unique<Shader>("rsc/shaders/vertex.glsl", "rsc/shaders/fragment.glsl");
@@ -29,7 +25,7 @@ Renderer::Renderer() :
 	perspective = glm::perspective(glm::radians(45.0f), float(width)/height, 0.1f, 100.0f);
 	shader->use();
 	shader->setUniformMatrix4fv("perspective", perspective);
-	shader->setUniformMatrix4fv("view", camera.getViewMatrix());
+	shader->setUniformMatrix4fv("view", camera->getViewMatrix());
 
 	texture = std::make_unique<Texture>("rsc/images/tree.jpeg");
 	shader->setUniform1i("tex", 0);	// sets location of texture to 0.
@@ -64,9 +60,6 @@ void Renderer::initWindow()
 
 	glViewport(0, 0, width, height);
 
-	// Let GLFW store pointer to this instance of Renderer.
-	glfwSetWindowUserPointer(window, static_cast<void*>(this));
-
 	glfwSetFramebufferSizeCallback(window,
 			[](GLFWwindow* window, int newWidth, int newHeight) {
 
@@ -76,200 +69,36 @@ void Renderer::initWindow()
 		renderer->perspective = glm::perspective(glm::radians(45.0f), float(newWidth)/newHeight, 0.1f, 100.0f);
 	});
  
-	glfwSetKeyCallback(window, keyCallback);
-    glfwSetCursorPosCallback(window, mouseCallback);
-    // tell GLFW to capture our mouse
-    glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 	glEnable(GL_DEPTH_TEST);
 
 }
 
 GLFWwindow* Renderer::getWindow() { return window; }
 
-void Renderer::run(float _deltaSec, DevUI& devUI, std::vector<std::unique_ptr<Model>>& models)
+void Renderer::run(float deltaSec, DevUI& devUI, std::vector<std::unique_ptr<Model>>& models)
 {
-	deltaSec = _deltaSec;
 	glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-	processWindowInput();
-
 	shader->use();
-	shader->setUniformMatrix4fv("view", camera.getViewMatrix());
+	shader->setUniformMatrix4fv("view", camera->getViewMatrix());
 	shader->setUniformMatrix4fv("perspective", perspective);
 
 	texture->bind(GL_TEXTURE0);	// we set the uniform in fragment shader to location 0.
 
 	for (auto& model : models)
 	{
-		model->rotate(rotate);
-		model->scale(scale);
-		model->update();
 		model->draw(*shader);
 	}
 
 	glUseProgram(0);
 
-	rotate = glm::vec3(0.0f);
-	scale = 1;
-
 	devUI.show(deltaSec);
 
 	glfwSwapBuffers(window);
-	glfwPollEvents();
 }
 
-/*
- * This method typically runs faster than handling a key callback.
- * So controls like movements should be placed in here.
- */
-void Renderer::processWindowInput()
-{
-	float rotationSpeed = glm::radians(135.0f) * deltaSec;
-	float scaleSpeed = 1.0f + 1.0f * deltaSec;
-	shiftPressed = glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS;
 
-	// Rotations
-	if (!shiftPressed)
-	{
-		if(glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS)
-		{
-			rotate.x -= rotationSpeed;
-		}
-
-		if(glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS)
-		{
-			rotate.x += rotationSpeed;
-		}
-
-		if(glfwGetKey(window, GLFW_KEY_E) == GLFW_PRESS)
-		{
-			rotate.y += rotationSpeed;
-		}
-
-		if(glfwGetKey(window, GLFW_KEY_Q) == GLFW_PRESS)
-		{
-			rotate.y -= rotationSpeed;
-		}
-
-		if(glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS)
-		{
-			rotate.z -= rotationSpeed;
-		}
-
-		if(glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS)
-		{
-			rotate.z += rotationSpeed;
-		}
-	}
-
-	// Camera Movement
-	if (shiftPressed)
-	{
-		if(glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS)
-		{
-			camera.processKeyboard(Camera::Movement::FORWARD, deltaSec);
-		}
-
-		if(glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS)
-		{
-			camera.processKeyboard(Camera::Movement::BACKWARD, deltaSec);
-		}
-
-		if(glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS)
-		{
-			camera.processKeyboard(Camera::Movement::RIGHT, deltaSec);
-		}
-
-		if(glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS)
-		{
-			camera.processKeyboard(Camera::Movement::LEFT, deltaSec);
-		}
-
-		if(glfwGetKey(window, GLFW_KEY_E) == GLFW_PRESS)
-		{
-			camera.processKeyboard(Camera::Movement::UP, deltaSec);
-		}
-
-		if(glfwGetKey(window, GLFW_KEY_Q) == GLFW_PRESS)
-		{
-			camera.processKeyboard(Camera::Movement::DOWN, deltaSec);
-		}
-	}
-
-	// Scaling
-	if(glfwGetKey(window, GLFW_KEY_Z) == GLFW_PRESS)
-	{
-		scale *= scaleSpeed;
-	}
-	if(glfwGetKey(window, GLFW_KEY_X) == GLFW_PRESS)
-	{
-		scale /= scaleSpeed;
-	}
-
-	if (glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_PRESS)
-	{
-		if (sceneSelect == 0)
-		{
-			changeScene(1);
-		}
-		else if (sceneSelect == 1) 
-		{
-			changeScene(0);
-		}
-	}
-}
-
-/*
- * Handle keyboard inputs that don't require frequent repeated actions,
- * ex closing window, selecting model etc.
- */ 
-void Renderer::keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)
-{
-	Renderer* renderer = static_cast<Renderer*>(glfwGetWindowUserPointer(window));
-	
-	if (action == GLFW_PRESS)
-	{
-		switch(key)
-		{
-			case GLFW_KEY_ESCAPE:
-				glfwSetWindowShouldClose(window, true);
-				break;
-
-			case GLFW_KEY_SPACE:
-				if (mods & GLFW_MOD_CONTROL)
-				{
-					renderer->showCursor = !renderer->showCursor;
-					int cursorMode = renderer->showCursor ? GLFW_CURSOR_NORMAL : GLFW_CURSOR_DISABLED;
-					glfwSetInputMode(window, GLFW_CURSOR, cursorMode);
-				}
-				break;
-		}
-	}
-}
-
-void Renderer::mouseCallback(GLFWwindow* window, double xpos, double ypos)
-{
-	Renderer* renderer = static_cast<Renderer*>(glfwGetWindowUserPointer(window));
-
-	if (!renderer->showCursor)
-	{
-		if (renderer->firstMouse)
-		{
-			renderer->lastX = xpos;
-			renderer->lastY = ypos;
-			renderer->firstMouse = false;
-		}
-
-		float xoffset = xpos - renderer->lastX;
-		float yoffset = renderer->lastY - ypos; // reversed since y-coordinates go from bottom to top
-
-		renderer->lastX = xpos;
-		renderer->lastY = ypos;
-
-		renderer->camera.processMouseMovement(xoffset, yoffset);
-	}
-}
 
 bool Renderer::isWindowClosed() const
 {

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -9,12 +9,13 @@
 #include "Renderer.h"
 
 
-/////////////////////////////////////////////////////////////////////////////////////////
-
-using namespace physx;
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
+/*
+* Constructs a renderer and initializes GLFW and GLAD. Note that OpenGL functions will
+* not be available until GLAD is initialized.
+* 
+* Parameters:
+	camera: The camera for the scene. The renderer will not the alter the camera in any way.
+*/
 Renderer::Renderer(const std::shared_ptr<Camera> camera) : camera(camera), showCursor(false)
 {
 	initWindow();
@@ -75,7 +76,15 @@ void Renderer::initWindow()
 
 GLFWwindow* Renderer::getWindow() { return window; }
 
-void Renderer::run(float deltaSec, DevUI& devUI, std::vector<std::unique_ptr<Model>>& models)
+/*
+* Renderer a frame.
+* 
+* Parameters:
+*	deltaSec: How much time has elapsed in seconds since the last frame was rendered.
+*	devUI: An imgui window.
+*	models: All the models to renderer this frame.
+*/
+void Renderer::render(float deltaSec, DevUI& devUI, std::vector<std::unique_ptr<Model>>& models)
 {
 	glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -15,7 +15,7 @@ using namespace physx;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-Renderer::Renderer(const std::shared_ptr<Camera> camera) : camera(camera)
+Renderer::Renderer(const std::shared_ptr<Camera> camera) : camera(camera), showCursor(false)
 {
 	initWindow();
 	shader = std::make_unique<Shader>("rsc/shaders/vertex.glsl", "rsc/shaders/fragment.glsl");
@@ -98,9 +98,24 @@ void Renderer::run(float deltaSec, DevUI& devUI, std::vector<std::unique_ptr<Mod
 	glfwSwapBuffers(window);
 }
 
-
+void Renderer::setWindowShouldClose(bool close)
+{
+	glfwSetWindowShouldClose(window, close);
+}
 
 bool Renderer::isWindowClosed() const
 {
 	return glfwWindowShouldClose(window);
+}
+
+void Renderer::toggleCursor()
+{
+	showCursor = !showCursor;
+	int cursorMode = showCursor ? GLFW_CURSOR_NORMAL : GLFW_CURSOR_DISABLED;
+	glfwSetInputMode(window, GLFW_CURSOR, cursorMode);
+}
+
+bool Renderer::isCursorShowing() const
+{
+	return showCursor;
 }

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -22,7 +22,10 @@ class Renderer
 		GLFWwindow* getWindow();
 		void run(float deltaSec, DevUI& devUI, std::vector<std::unique_ptr<Model>>& models);
 
+		void setWindowShouldClose(bool close);
 		bool isWindowClosed() const;
+		void toggleCursor();
+		bool isCursorShowing() const;
 
 	private:
 		GLFWwindow* window;
@@ -35,6 +38,8 @@ class Renderer
 
 		const std::shared_ptr<Camera> camera;
 		glm::mat4 perspective;
+
+		bool showCursor;
 
 		void initWindow();
 };

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -20,7 +20,7 @@ class Renderer
 		~Renderer();
 
 		GLFWwindow* getWindow();
-		void run(float deltaSec, DevUI& devUI, std::vector<std::unique_ptr<Model>>& models);
+		void render(float deltaSec, DevUI& devUI, std::vector<std::unique_ptr<Model>>& models);
 
 		void setWindowShouldClose(bool close);
 		bool isWindowClosed() const;

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -16,13 +16,12 @@
 class Renderer
 {
 	public:
-		Renderer();
+		Renderer(const std::shared_ptr<Camera> camera);
 		~Renderer();
 
 		GLFWwindow* getWindow();
 		void run(float deltaSec, DevUI& devUI, std::vector<std::unique_ptr<Model>>& models);
 
-		void changeScene(int scene) { sceneSelect = scene; }
 		bool isWindowClosed() const;
 
 	private:
@@ -31,36 +30,11 @@ class Renderer
 		std::unique_ptr<Shader> shader;
 		std::unique_ptr<Texture> texture;
 		
-		unsigned int modelIndex;
-		
 		const unsigned int height = 800;
 		const unsigned int width = 800;
 
-		enum Scene
-		{
-			Test = 0,
-			PhysX = 1,
-		};
-
-		int sceneSelect;
-
-		glm::vec3 rotate;
-		float scale;
-		Camera camera;
+		const std::shared_ptr<Camera> camera;
 		glm::mat4 perspective;
 
-		bool firstMouse;
-		float lastX;
-		float lastY;
-		bool shiftPressed;
-
-		float deltaSec;
-		float lastFrame;
-
-		bool showCursor;
-
 		void initWindow();
-		void processWindowInput();
-		static void keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
-		static void mouseCallback(GLFWwindow* window, double xpos, double ypos);
 };

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -2,10 +2,9 @@
 
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
+#include <glm/glm.hpp>
 #include <vector>
 #include <string>
-#include <glm/glm.hpp>
-
 #include <memory>
 
 #include "Model.h"
@@ -21,7 +20,7 @@ class Renderer
 		~Renderer();
 
 		GLFWwindow* getWindow();
-		void run(float deltaSec, DevUI& devUI);
+		void run(float deltaSec, DevUI& devUI, std::vector<std::unique_ptr<Model>>& models);
 
 		void changeScene(int scene) { sceneSelect = scene; }
 		bool isWindowClosed() const;
@@ -31,7 +30,7 @@ class Renderer
 
 		std::unique_ptr<Shader> shader;
 		std::unique_ptr<Texture> texture;
-		std::vector<std::unique_ptr<Model>> models;
+		
 		unsigned int modelIndex;
 		
 		const unsigned int height = 800;
@@ -61,7 +60,6 @@ class Renderer
 		bool showCursor;
 
 		void initWindow();
-		void loadModels();
 		void processWindowInput();
 		static void keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
 		static void mouseCallback(GLFWwindow* window, double xpos, double ypos);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,3 @@
-//#include "Renderer.h"
 #include "Engine.h"
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
* Keyboard/mouse IO is handled in the `Engine` for now. It should eventually go into its own `UserInput` and/or `GamePad` class.
* Some code from the `Renderer` can be placed in the `Model`, such as the `Texture` and `Shader`.