### PR TITLE
Implement a IRendereble interface.

### DIFF
--- a/src/Arena.cpp
+++ b/src/Arena.cpp
@@ -6,10 +6,10 @@ Arena::Tile::Tile(const std::shared_ptr<Model> tile, const std::shared_ptr<Model
 
 }
 
-void Arena::Tile::draw(const Shader& shader) const
+void Arena::Tile::render(const Shader& shader) const
 {
-	tile.draw(shader);
-	tileBorder.draw(shader);
+	tile.render(shader);
+	tileBorder.render(shader);
 }
 
 void Arena::Tile::translate(const glm::vec3& trans)
@@ -52,13 +52,13 @@ Arena::Arena(const std::shared_ptr<Model> tile, const std::shared_ptr<Model> til
 
 Arena::~Arena() {}
 
-void Arena::draw(const Shader& shader) const
+void Arena::render(const Shader& shader) const
 {
-	for (auto& row : tileGrid)
+	for (const auto& row : tileGrid)
 	{
-		for (auto& tile : row)
+		for (const auto& tile : row)
 		{
-			tile.draw(shader);
+			tile.render(shader);
 		}
 	}
 }

--- a/src/Arena.h
+++ b/src/Arena.h
@@ -6,20 +6,22 @@
 #include <memory>
 
 #include "Model.h"
+#include "Renderer.h"
+#include "Shader.h"
 
-class Arena
+class Arena : public Renderer::IRenderable
 {
 public:
 	Arena(const std::shared_ptr<Model> tile, const std::shared_ptr<Model> tileBorder, unsigned int length, unsigned int width);
 	~Arena();
 
-	void draw(const Shader& shader) const;
+	void render(const Shader& shader) const;
 	
 private:
-	class Tile {
+	class Tile : public Renderer::IRenderable {
 	public:
 		Tile(const std::shared_ptr<Model> tile, const std::shared_ptr<Model> tileBorder);
-		void draw(const Shader& shader) const;
+		void render(const Shader& shader) const;
 		void translate(const glm::vec3& trans);
 
 	private:

--- a/src/DevUI.cpp
+++ b/src/DevUI.cpp
@@ -26,10 +26,15 @@ DevUI::DevUI(GLFWwindow* window) : showDemo(false)
 DevUI::~DevUI() {}
 
 
+void DevUI::update(float deltaSec)
+{
+    _deltaSec = deltaSec;
+}
+
 /**
  * This method should be called every frame by the Renderer. 
 */
-void DevUI::show(float deltaSec)
+void DevUI::render(const Shader& shader)
 {
     // Start the Dear ImGui frame
     ImGui_ImplOpenGL3_NewFrame();
@@ -42,7 +47,7 @@ void DevUI::show(float deltaSec)
     }
 
     ImGui::Begin("Dev Settings");
-    ImGui::Text("Application average %.3f ms/frame %.3f FPS", deltaSec*1000, 1/deltaSec);
+    ImGui::Text("Application average %.3f ms/frame %.3f FPS", _deltaSec*1000, 1/_deltaSec);
     ImGui::SliderInt("FPS Cap", &sliderFPS, 30, 144);
 
     ImGui::End();

--- a/src/DevUI.cpp
+++ b/src/DevUI.cpp
@@ -34,7 +34,7 @@ void DevUI::update(float deltaSec)
 /**
  * This method should be called every frame by the Renderer. 
 */
-void DevUI::render(const Shader& shader)
+void DevUI::render()
 {
     // Start the Dear ImGui frame
     ImGui_ImplOpenGL3_NewFrame();

--- a/src/DevUI.h
+++ b/src/DevUI.h
@@ -4,13 +4,17 @@
 #include <GLFW/glfw3.h>
 #include <glm/glm.hpp>
 
+#include "Renderer.h"
+
 class DevUI
 {
 public:
 	DevUI(GLFWwindow* window);
 	~DevUI();
-	void show(float deltaSec);
+	void update(float deltaSec);
+	void render(const Shader& shader);
 	int getSliderFPS();
 private:
 	bool showDemo;
+	float _deltaSec;
 };

--- a/src/DevUI.h
+++ b/src/DevUI.h
@@ -4,7 +4,6 @@
 #include <GLFW/glfw3.h>
 #include <glm/glm.hpp>
 
-#include "Renderer.h"
 
 class DevUI
 {
@@ -12,7 +11,7 @@ public:
 	DevUI(GLFWwindow* window);
 	~DevUI();
 	void update(float deltaSec);
-	void render(const Shader& shader);
+	void render();
 	int getSliderFPS();
 private:
 	bool showDemo;

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -69,9 +69,11 @@ void Engine::initEntities()
 {
 	// load boxcar > physicsModels[0]
 	vehicle = loadModel("rsc/models/boxcar.obj", true, Model::MoveType::DYNAMIC, face);
+	renderables.push_back(vehicle);
 
 	// background box > staticModels[0]
 	skyBox = loadModel("rsc/models/cube.obj", false, Model::MoveType::STATIC, background);
+	renderables.push_back(skyBox);
 
 	bool copyModel = true;
 	tile = loadModel("rsc/models/tile.obj", false, Model::MoveType::STATIC, nullptr, glm::vec4(0.3, 0.3, 0.3 ,0), copyModel);
@@ -97,7 +99,8 @@ void Engine::run()
 	skyBox->scale(100);
 	skyBox->update();
 
-	Arena arena(tile, tileBorder, 25, 25);
+	std::shared_ptr<Arena> arena = std::make_shared<Arena>(tile, tileBorder, 25, 25);
+	renderables.push_back(arena);
 
 	while (!controller.isWindowClosed()) {
 		// update global time
@@ -112,6 +115,7 @@ void Engine::run()
 			deltaSec = currentFrame - lastFrame;
 		}
 		lastFrame = currentFrame;
+		devUI.update(deltaSec);
 
 		// controller 
 		controller.processInput(deltaSec);
@@ -128,7 +132,7 @@ void Engine::run()
 		}
 
 		// render the updated position of all models and ImGui
-		renderer.render(deltaSec, devUI, staticModels, physicsModels, arena);
+		renderer.render(renderables);
 
 		glfwPollEvents();
 	}

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -132,7 +132,7 @@ void Engine::run()
 		}
 
 		// render the updated position of all models and ImGui
-		renderer.render(renderables);
+		renderer.render(renderables, devUI);
 
 		glfwPollEvents();
 	}

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -38,6 +38,7 @@ private:
 	std::vector<std::shared_ptr<Vehicle>> vehicles;
 	std::vector<std::shared_ptr<Model>> staticModels;
 	std::vector<std::shared_ptr<Model>> physicsModels;
+	std::vector<std::shared_ptr<Renderer::IRenderable>> renderables;
 
 	// These should eventually be their specific classes rather than Model.
 	// e.g. the plane should be Arena, car should be Vehicle.

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -80,7 +80,7 @@ void Model::extractDataFromNode(const aiScene* scene, const aiNode* node)
  * Draws the model. Remember to update() the model first.
  * Assumes the shader is already in use.
  */
-void Model::draw(const Shader& shader) const
+void Model::render(const Shader& shader) const
 {
 	
 	bool hasTexture = m_texture != nullptr;

--- a/src/Model.h
+++ b/src/Model.h
@@ -7,9 +7,10 @@
 
 #include "Mesh.h"
 #include "Shader.h"
+#include "Renderer.h"
 #include "Texture.h"
 
-class Model
+class Model : public Renderer::IRenderable
 {
 	public:
 		enum MoveType {
@@ -26,7 +27,7 @@ class Model
 		Model(const Model& model);
 		~Model();
 
-		void draw(const Shader& shader) const;
+		void render(const Shader& shader) const;
 		void update();
 		void updateModelMatrix(glm::mat4& modelPose);
 		void translate(const glm::vec3& translate);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -81,10 +81,7 @@ GLFWwindow* Renderer::getWindow() { return window; }
 *	models: All the models to renderer this frame.
 */
 
-void Renderer::render(	float deltaSec, DevUI& devUI, 
-						std::vector<std::shared_ptr<Model>>& staticModels,
-						std::vector<std::shared_ptr<Model>>& physicsModels,
-						Arena & arena)
+void Renderer::render(const std::vector<std::shared_ptr<IRenderable>>& renderables)
 {
 	glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -94,21 +91,12 @@ void Renderer::render(	float deltaSec, DevUI& devUI,
 	shader->setUniformMatrix4fv("perspective", perspective);
 
 
-	for (const auto& model : physicsModels)
+	for (const auto& renderable : renderables)
 	{
-		model->draw(*shader);
+		renderable->render(*shader);
 	}
-
-	for (const auto& model : staticModels)
-	{
-		model->draw(*shader);
-	}
-
-	arena.draw(*shader);
 
 	glUseProgram(0);
-
-	devUI.show(deltaSec);
 
 	glfwSwapBuffers(window);
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -81,7 +81,7 @@ GLFWwindow* Renderer::getWindow() { return window; }
 *	models: All the models to renderer this frame.
 */
 
-void Renderer::render(const std::vector<std::shared_ptr<IRenderable>>& renderables)
+void Renderer::render(const std::vector<std::shared_ptr<IRenderable>>& renderables, DevUI& devUI)
 {
 	glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -97,6 +97,8 @@ void Renderer::render(const std::vector<std::shared_ptr<IRenderable>>& renderabl
 	}
 
 	glUseProgram(0);
+
+	devUI.render();
 
 	glfwSwapBuffers(window);
 }

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -7,8 +7,8 @@
 #include <string>
 #include <memory>
 
-#include "Shader.h"
 #include "Camera.h"
+#include "DevUI.h"
 #include "Texture.h"
 
 class Renderer
@@ -25,7 +25,7 @@ class Renderer
 
 		GLFWwindow* getWindow();
 
-		void render(const std::vector<std::shared_ptr<IRenderable>>& renderables);
+		void render(const std::vector<std::shared_ptr<IRenderable>>& renderables, DevUI& devUI);
 
 	private:
 		GLFWwindow* window;

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -7,25 +7,25 @@
 #include <string>
 #include <memory>
 
-#include "Arena.h"
-#include "Model.h"
 #include "Shader.h"
 #include "Camera.h"
 #include "Texture.h"
-#include "DevUI.h"
 
 class Renderer
 {
 	public:
+		class IRenderable
+		{
+		public:
+			virtual void render(const Shader& shader) const = 0;
+		};
+
 		Renderer(const Camera& camera);
 		~Renderer();
 
 		GLFWwindow* getWindow();
 
-		void render(float deltaSec, DevUI& devUI,
-			std::vector<std::shared_ptr<Model>>& staticModels,
-			std::vector<std::shared_ptr<Model>>& physicsModels,
-			Arena& arena);
+		void render(const std::vector<std::shared_ptr<IRenderable>>& renderables);
 
 	private:
 		GLFWwindow* window;


### PR DESCRIPTION
Simplify rendering by having the `Renderer` take in an `std::vector<IRenderable>`.

Currently only `Model`, `Arena` and `Tile` are `IRenderables`.

`DevUI` can't inherit from `IRenderable` because it can't make `render()` a `const` function. It also doesn't need a `Shader`.