### PR TITLE
Change tile color to vehicle color

### DIFF
--- a/src/Arena.cpp
+++ b/src/Arena.cpp
@@ -41,10 +41,10 @@ Arena::Arena(const std::shared_ptr<Model> tile, const std::shared_ptr<Model> til
 	{
 		tileGrid[row] = std::vector<Tile>(cols, Tile(tile, tileBorder));
 
-		trans.z = -(rows / 2.f) * tileBox.depth + (row * tileBox.depth);
+		trans.z = -(rows * .5f) * tileBox.depth + (row * tileBox.depth) + tileBox.depth * 0.5;
 		for (unsigned int col = 0; col < tileGrid[row].size(); col++)
 		{
-			trans.x = -(cols / 2.f) * tileBox.width + (col * tileBox.width);
+			trans.x = -(cols * .5f) * tileBox.width + (col * tileBox.width) + tileBox.width * .5f;
 			tileGrid[row][col].translate(trans);
 		}
 	}

--- a/src/Arena.cpp
+++ b/src/Arena.cpp
@@ -21,6 +21,11 @@ void Arena::Tile::translate(const glm::vec3& trans)
 	tileBorder.update();
 }
 
+void Arena::Tile::setColor(const glm::vec4& color)
+{
+	tile.setColor(color);
+}
+
 /*
  Construct an arena:
 
@@ -31,7 +36,7 @@ void Arena::Tile::translate(const glm::vec3& trans)
 	cols: The number of tiles on the x-axis.
 */
 Arena::Arena(const std::shared_ptr<Model> tile, const std::shared_ptr<Model> tileBorder, unsigned int rows, unsigned int cols) :
-	tileGrid(rows)
+	tileGrid(rows), tileCollisionRadius(0.5f)
 {
 	const BoundingBox& tileBox = tileBorder->getBoundingBox();
 	glm::vec3 trans(0.f);
@@ -48,6 +53,9 @@ Arena::Arena(const std::shared_ptr<Model> tile, const std::shared_ptr<Model> til
 			tileGrid[row][col].translate(trans);
 		}
 	}
+
+	tileWidth = tileBox.width;
+	tileDepth = tileBox.depth;
 }
 
 Arena::~Arena() {}
@@ -61,4 +69,34 @@ void Arena::render(const Shader& shader) const
 			tile.render(shader);
 		}
 	}
+}
+
+/*
+ * Returns the coordinates of the tile, if any, that the given coordinates are over.
+ * Does not check the y-axis, only x and z. This function also uses the predefined radius
+ * as a tolerance.
+*/
+std::optional<glm::vec2> Arena::isOnTile(const glm::vec3& coords) const
+{
+	unsigned int rows = tileGrid.size();
+	unsigned int cols = tileGrid[0].size();
+
+	int col = (coords.x + (cols * .5f) * tileWidth) / tileWidth;
+	int row = (coords.z + (rows * .5f) * tileDepth) / tileDepth;
+
+	if (col < 0 || col > cols - 1 || row < 0 || row > rows - 1)
+	{
+		// Make sure the column and row are within the bounds.
+		return std::nullopt;
+	}
+
+	// TO-DO:
+	// Make sure the coordinates are within the raidus tolerance.
+
+	return glm::vec2(row, col);
+}
+
+void Arena::setTileColor(const glm::vec2& tileCoords, const glm::vec4& color)
+{
+	tileGrid[tileCoords.x][tileCoords.y].setColor(color);
 }

--- a/src/Arena.h
+++ b/src/Arena.h
@@ -2,6 +2,7 @@
 
 #include <glm/glm.hpp>
 
+#include <optional>
 #include <vector>
 #include <memory>
 
@@ -16,6 +17,9 @@ public:
 	~Arena();
 
 	void render(const Shader& shader) const;
+	std::optional<glm::vec2> isOnTile(const glm::vec3& coords) const;
+
+	void setTileColor(const glm::vec2& tileCoords, const glm::vec4& color);
 	
 private:
 	class Tile : public Renderer::IRenderable {
@@ -23,6 +27,7 @@ private:
 		Tile(const std::shared_ptr<Model> tile, const std::shared_ptr<Model> tileBorder);
 		void render(const Shader& shader) const;
 		void translate(const glm::vec3& trans);
+		void setColor(const glm::vec4& color);
 
 	private:
 		Model tile;
@@ -31,4 +36,8 @@ private:
 
 	using TileGrid = std::vector<std::vector<Tile>>;
 	TileGrid tileGrid;
+
+	float tileWidth;
+	float tileDepth;
+	float tileCollisionRadius;
 };

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -68,7 +68,7 @@ void Engine::loadTextures()
 void Engine::initEntities()
 {
 	// load boxcar > physicsModels[0]
-	vehicle = loadModel("rsc/models/boxcar.obj", true, Model::MoveType::DYNAMIC, face);
+	vehicle = loadModel("rsc/models/boxcar.obj", true, Model::MoveType::DYNAMIC, face, glm::vec4(.3f, .3f, 1.f, 0.f));
 	renderables.push_back(vehicle);
 
 	// background box > staticModels[0]
@@ -76,8 +76,8 @@ void Engine::initEntities()
 	renderables.push_back(skyBox);
 
 	bool copyModel = true;
-	tile = loadModel("rsc/models/tile.obj", false, Model::MoveType::STATIC, nullptr, glm::vec4(0.3, 0.3, 0.3 ,0), copyModel);
-	tileBorder = loadModel("rsc/models/tile_edge.obj", false, Model::MoveType::STATIC, nullptr, glm::vec4(0.2 ,0.2 ,0.2 ,0), copyModel);
+	tile = loadModel("rsc/models/tile.obj", false, Model::MoveType::STATIC, nullptr, glm::vec4(0.3f, 0.3f, 0.3f ,0.f), copyModel);
+	tileBorder = loadModel("rsc/models/tile_edge.obj", false, Model::MoveType::STATIC, nullptr, glm::vec4(0.2f ,0.2f ,0.2f ,0.f), copyModel);
 
 }
 
@@ -122,6 +122,7 @@ void Engine::run()
 
 		// run a frame of simulation
 		simulator.stepPhysics(controller.output);
+		simulator.checkVehicleOverTile(*arena, *vehicle);
 		
 
 		// set camera to player vehicles position

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -115,7 +115,7 @@ void Model::update()
 	m_scale = 1;
 }
 
-void Model::updateModelMatrix(glm::mat4& modelPose)
+void Model::setModelMatrix(const glm::mat4& modelPose)
 {
 	modelMatrix = modelPose;
 }
@@ -139,14 +139,14 @@ void Model::scale(const float scale)
 	m_scale = scale;
 }
 
-void Model::setPosition(glm::vec3 _position)
+void Model::setPosition(const glm::vec3& position)
 {
-	wPosition = _position;
+	m_position = position;
 }
 
 const glm::vec3& Model::getPosition() const
 {
-	return wPosition;
+	return m_position;
 }
 
 void Model::computeBoundingBox()

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -139,16 +139,6 @@ void Model::scale(const float scale)
 	m_scale = scale;
 }
 
-void Model::setPosition(const glm::vec3& position)
-{
-	m_position = position;
-}
-
-const glm::vec3& Model::getPosition() const
-{
-	return m_position;
-}
-
 void Model::computeBoundingBox()
 {
 	float minX = meshes[0]->getBoundingBox().x;
@@ -202,3 +192,11 @@ bool Model::isDynamic() const { return dynamicObject; }
 const std::vector<std::unique_ptr<Mesh>>& Model::getMeshes() const { return meshes; }
 
 const BoundingBox& Model::getBoundingBox() const { return boundingBox; }
+
+const glm::vec4& Model::getColor() const { return m_color;  }
+
+void Model::setColor(const glm::vec4& color) { m_color = color; }
+
+void Model::setPosition(const glm::vec3& position) { m_position = position; }
+
+const glm::vec3& Model::getPosition() const { return m_position; }

--- a/src/Model.h
+++ b/src/Model.h
@@ -34,12 +34,14 @@ class Model : public Renderer::IRenderable
 		void rotate(const glm::vec3 &rotate);
 		void scale(float scale);
 
-		void setPosition(const glm::vec3& position);
 		bool isDynamic() const;
 
 		const std::vector<std::unique_ptr<Mesh>>& getMeshes() const;
 
+		void setPosition(const glm::vec3& position);
 		const glm::vec3& getPosition() const;
+		void setColor(const glm::vec4& color);
+		const glm::vec4& getColor() const;
 		const BoundingBox& getBoundingBox() const;
 
 		bool shouldRender = false;

--- a/src/Model.h
+++ b/src/Model.h
@@ -29,12 +29,12 @@ class Model : public Renderer::IRenderable
 
 		void render(const Shader& shader) const;
 		void update();
-		void updateModelMatrix(glm::mat4& modelPose);
+		void setModelMatrix(const glm::mat4& modelPose);
 		void translate(const glm::vec3& translate);
 		void rotate(const glm::vec3 &rotate);
 		void scale(float scale);
 
-		void setPosition(glm::vec3 position);
+		void setPosition(const glm::vec3& position);
 		bool isDynamic() const;
 
 		const std::vector<std::unique_ptr<Mesh>>& getMeshes() const;
@@ -52,7 +52,7 @@ class Model : public Renderer::IRenderable
 		glm::vec3 m_rotate;			// how much to rotate along each axis
 		float m_scale;				// scale to apply to model
 		glm::vec3 m_translation;	// translation vector
-		glm::vec3 wPosition;
+		glm::vec3 m_position;
 		glm::vec4 m_color;
 
 		int const dynamicObject;

--- a/src/Simulate.cpp
+++ b/src/Simulate.cpp
@@ -432,8 +432,6 @@ void Simulate::setModelPose(std::shared_ptr<Model>& model)
 	{
 		std::vector<PxRigidActor*> actors(numActors);
 		gScene->getActors(PxActorTypeFlag::eRIGID_DYNAMIC | PxActorTypeFlag::eRIGID_STATIC, reinterpret_cast<PxActor**>(&actors[0]), numActors);
-		
-		std::cout << "number of actors: " << numActors << std::endl;
 
 		PxShape* shapes[128]; // max number of shapes per actor is 128
 		for (int i = 0; i < numActors; i++)
@@ -446,14 +444,14 @@ void Simulate::setModelPose(std::shared_ptr<Model>& model)
 				if (shapes[j]->getGeometryType() == PxGeometryType::eCONVEXMESH)
 				{
 					PxMat44 boxPose(PxShapeExt::getGlobalPose(*shapes[j], *actors[i]));
-					glm::mat4 boxUpdate(glm::vec4(boxPose.column0.x, boxPose.column0.y, boxPose.column0.z, 0.0f),
-										glm::vec4(boxPose.column1.x, boxPose.column1.y, boxPose.column1.z, 0.0f),
-										glm::vec4(boxPose.column2.x, boxPose.column2.y, boxPose.column2.z, 0.0f),
-										glm::vec4(boxPose.column3.x, boxPose.column3.y, boxPose.column3.z, 1.0f));
-					model->updateModelMatrix(boxUpdate);
-					model->setPosition(	glm::vec3(	boxPose.getPosition().x,
-													boxPose.getPosition().y,
-													boxPose.getPosition().z));
+					
+					glm::mat4 modelMatrix;
+					std::memcpy(&modelMatrix, &boxPose, sizeof(PxMat44));
+					model->setModelMatrix(modelMatrix);
+					
+					glm::vec3 modelPos;
+					std::memcpy(&modelPos, &(boxPose.getPosition()), sizeof(PxVec3));
+					model->setPosition(modelPos);
 				}
 			}
 		}

--- a/src/Simulate.cpp
+++ b/src/Simulate.cpp
@@ -458,6 +458,15 @@ void Simulate::setModelPose(std::shared_ptr<Model>& model)
 	}
 }
 
+void Simulate::checkVehicleOverTile(Arena& arena, Model& model)
+{
+	std::optional<glm::vec2> tileCoords = arena.isOnTile(model.getPosition());
+	if (tileCoords)
+	{
+		arena.setTileColor(*tileCoords, model.getColor());
+	}
+}
+
 void Simulate::cookMeshes()
 {
 	for (auto& model : physicsModels)

--- a/src/Simulate.h
+++ b/src/Simulate.h
@@ -19,6 +19,7 @@ public:
 	void stepPhysics(bool input[]);
 	void setModelPose(std::shared_ptr<Model>& model);
 	void cookMeshes();
+	void checkVehicleOverTile(Arena& arena, Model& model);
 
 	void cleanupPhysics();
 private:


### PR DESCRIPTION
* Set the color of the tile to the color of the vehicle when the vehicle passes over the tile.
* No tolerance is being used, so as soon as the vehicle is over the tile the color changes.
* Vehicle is currently floating, if we decide to keep it floating we should have a light/shadow shining underneath the vehicle so the player has a sense of the vehicles position.
