### PR TITLE
Resize and moved the vehicle model

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -96,10 +96,10 @@ void Camera::updateCameraVectors()
 
 void Camera::updateCameraVectors(glm::vec3 vehPosition, glm::vec3 poi)
 {
-	float newX = vehPosition.x - (poi.x - vehPosition.x)*3.f;
-	float newZ = vehPosition.z - (poi.z - vehPosition.z)*3.f;
+	float newX = vehPosition.x - (poi.x - vehPosition.x)*4.f;
+	float newZ = vehPosition.z - (poi.z - vehPosition.z)*4.f;
 	
-	position = { newX, 5.f, newZ };
+	position = { newX, 2.f, newZ };
 	front = glm::normalize(poi - position);
 	right = glm::normalize(glm::cross(front, worldUp));
 	up = glm::normalize(glm::cross(right, front));

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -76,13 +76,13 @@ void Engine::initEntities()
 	glm::vec4 playerColor = glm::vec4(.3f, .3f, 1.f, 0.f);
 	glm::vec4 ai1Color = glm::vec4(.8f, .8f, .3f, 0.f);
 	
-	std::shared_ptr<Vehicle> player = std::make_shared<Vehicle>("player", playerColor, glm::vec3(0.f, 3.f, 0.f), glm::vec3(1.f, 0.f, 0.f));
+	std::shared_ptr<Vehicle> player = std::make_shared<Vehicle>("player", playerColor, glm::vec3(0.f, 1.f, 0.f), glm::vec3(1.f, 0.f, 0.f));
 	vehicles.push_back(player);
 	renderables.push_back(std::static_pointer_cast<Renderer::IRenderable>(player));
 	physicsModels.push_back(std::static_pointer_cast<IPhysical>(player));
 	
 
-	std::shared_ptr<Vehicle> ai1 = std::make_shared<Vehicle>("ai1", ai1Color, glm::vec3(15.f, 7.f, -15.f), glm::vec3(0.f, 0.f, -1.f));
+	std::shared_ptr<Vehicle> ai1 = std::make_shared<Vehicle>("ai1", ai1Color, glm::vec3(14.f, 3.f, -14.f), glm::vec3(0.f, 0.f, -1.f));
 	vehicles.push_back(ai1);
 	renderables.push_back(std::static_pointer_cast<Renderer::IRenderable>(ai1));
 	physicsModels.push_back(std::static_pointer_cast<IPhysical>(ai1));
@@ -121,8 +121,8 @@ void Engine::run()
 	Controller controller(renderer.getWindow(), camera, vehicles[0]);
 
 	// SOUND SETUP
-	audioPlayer->playGameMusic();
-	audioPlayer->playCarIdle();
+	//audioPlayer->playGameMusic();
+	//audioPlayer->playCarIdle();
 
 	while (!controller.isWindowClosed()) {
 		// update global time

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -33,7 +33,7 @@ Model::Model(const std::string& objPath,
 	{
 		for (auto& mesh : meshes)
 		{
-			mesh->setInstanceColors(*m_instanceColors);
+			mesh->setInstanceColors(*m_instanceColors); 
 		}
 	}
 
@@ -133,9 +133,9 @@ void Model::update()
 	m_position = modelMatrix * glm::vec4(m_position, 1.f);
 
 	// Reset transformation values
-	m_translation = glm::vec3(0);
-	m_rotate = glm::vec3(0);
-	m_scale = glm::vec3(1);
+	//m_translation = glm::vec3(0);
+	//m_rotate = glm::vec3(0);
+	//m_scale = glm::vec3(1);
 }
 
 void Model::translate(const glm::vec3& _translate)

--- a/src/Simulate.cpp
+++ b/src/Simulate.cpp
@@ -155,8 +155,9 @@ VehicleDesc initVehicleDesc()
 	//Set up the chassis mass, dimensions, moment of inertia, and center of mass offset.
 	//The moment of inertia is just the moment of inertia of a cuboid but modified for easier steering.
 	//Center of mass offset is 0.65m above the base of the chassis and 0.25m towards the front.
-	const PxF32 chassisMass = 1500.0f;
-	const PxVec3 chassisDims(2.5f, 2.0f, 5.0f);
+	const float vehScale = 1 / 3.5f;
+	const PxF32 chassisMass = 800.0f; // default 1500
+	const PxVec3 chassisDims(4.f * vehScale, 2.5f * vehScale, 10.1f * vehScale);
 	const PxVec3 chassisMOI
 	((chassisDims.y * chassisDims.y + chassisDims.z * chassisDims.z) * chassisMass / 12.0f,
 		(chassisDims.x * chassisDims.x + chassisDims.z * chassisDims.z) * 0.8f * chassisMass / 12.0f,
@@ -165,8 +166,8 @@ VehicleDesc initVehicleDesc()
 
 	//Set up the wheel mass, radius, width, moment of inertia, and number of wheels.
 	//Moment of inertia is just the moment of inertia of a cylinder.
-	const PxF32 wheelMass = 20.0f;
-	const PxF32 wheelRadius = 0.5f;
+	const PxF32 wheelMass = 50.0f; // default 10
+	const PxF32 wheelRadius = 0.3f;
 	const PxF32 wheelWidth = 0.4f;
 	const PxF32 wheelMOI = 0.5f * wheelMass * wheelRadius * wheelRadius;
 	const PxU32 nbWheels = 6;

--- a/src/SnippetVehicle4WCreate.cpp
+++ b/src/SnippetVehicle4WCreate.cpp
@@ -51,15 +51,15 @@ void computeWheelCenterActorOffsets4W(const PxF32 wheelFrontZ, const PxF32 wheel
 	//Set the outside of the left and right wheels to be flush with the chassis.
 	//Set the top of the wheel to be just touching the underside of the chassis.
 	//Begin by setting the rear-left/rear-right/front-left,front-right wheels.
-	wheelCentreOffsets[PxVehicleDrive4WWheelOrder::eREAR_LEFT] = PxVec3((-chassisDims.x + wheelWidth)*0.5f, -(chassisDims.y/2 + wheelRadius), wheelRearZ + 0*deltaZ*0.5f);
-	wheelCentreOffsets[PxVehicleDrive4WWheelOrder::eREAR_RIGHT] = PxVec3((+chassisDims.x - wheelWidth)*0.5f, -(chassisDims.y/2 + wheelRadius), wheelRearZ + 0*deltaZ*0.5f);
-	wheelCentreOffsets[PxVehicleDrive4WWheelOrder::eFRONT_LEFT] = PxVec3((-chassisDims.x + wheelWidth)*0.5f, -(chassisDims.y/2 + wheelRadius), wheelRearZ + (numLeftWheels-1)*deltaZ);
-	wheelCentreOffsets[PxVehicleDrive4WWheelOrder::eFRONT_RIGHT] = PxVec3((+chassisDims.x - wheelWidth)*0.5f, -(chassisDims.y/2 + wheelRadius), wheelRearZ + (numLeftWheels-1)*deltaZ);
+	wheelCentreOffsets[PxVehicleDrive4WWheelOrder::eREAR_LEFT] = PxVec3((-chassisDims.x + wheelWidth)*0.5f, -(chassisDims.y/2), wheelRearZ + 0*deltaZ*0.5f);
+	wheelCentreOffsets[PxVehicleDrive4WWheelOrder::eREAR_RIGHT] = PxVec3((+chassisDims.x - wheelWidth)*0.5f, -(chassisDims.y/2), wheelRearZ + 0*deltaZ*0.5f);
+	wheelCentreOffsets[PxVehicleDrive4WWheelOrder::eFRONT_LEFT] = PxVec3((-chassisDims.x + wheelWidth)*0.5f, -(chassisDims.y/2), wheelRearZ + (numLeftWheels-1)*deltaZ);
+	wheelCentreOffsets[PxVehicleDrive4WWheelOrder::eFRONT_RIGHT] = PxVec3((+chassisDims.x - wheelWidth)*0.5f, -(chassisDims.y/2), wheelRearZ + (numLeftWheels-1)*deltaZ);
 	//Set the remaining wheels.
 	for(PxU32 i = 2, wheelCount = 4; i < numWheels-2; i+=2, wheelCount+=2)
 	{
-		wheelCentreOffsets[wheelCount + 0] = PxVec3((-chassisDims.x + wheelWidth)*0.5f, -(chassisDims.y/2 + wheelRadius), wheelRearZ + i*deltaZ*0.5f);
-		wheelCentreOffsets[wheelCount + 1] = PxVec3((+chassisDims.x - wheelWidth)*0.5f, -(chassisDims.y/2 + wheelRadius), wheelRearZ + i*deltaZ*0.5f);
+		wheelCentreOffsets[wheelCount + 0] = PxVec3((-chassisDims.x + wheelWidth)*0.5f, -(chassisDims.y/2), wheelRearZ + i*deltaZ*0.5f);
+		wheelCentreOffsets[wheelCount + 1] = PxVec3((+chassisDims.x - wheelWidth)*0.5f, -(chassisDims.y/2), wheelRearZ + i*deltaZ*0.5f);
 	}
 }
 

--- a/src/Vehicle.cpp
+++ b/src/Vehicle.cpp
@@ -135,12 +135,15 @@ void Vehicle::stopRight()
 void Vehicle::setModelMatrix(const glm::mat4& modelMat)
 {
 	// Probably a better way to do this, but this is fine for now.
-	float scale = 0.45f;
-	glm::mat4 scaled = modelMat;
-	scaled = glm::scale(modelMat, glm::vec3(scale));
-	body->setModelMatrix(scaled);
-	wheelsFront->setModelMatrix(scaled);
-	wheelsRear->setModelMatrix(scaled);
+	float scale = 1 / 3.5f; // this must match physX vehicle description in Simulate.cpp - initVehicleDesc()
+	glm::vec3 translate(0.f, -1.8f, 0.f);
+
+	glm::mat4 final_transform = modelMat;
+	final_transform = glm::scale(modelMat, glm::vec3(scale));
+	final_transform = glm::translate(final_transform, translate);
+	body->setModelMatrix(final_transform);
+	wheelsFront->setModelMatrix(final_transform);
+	wheelsRear->setModelMatrix(final_transform);
 }
 
 void Vehicle::setPosition(const glm::vec3& position)

--- a/src/Vehicle.h
+++ b/src/Vehicle.h
@@ -29,7 +29,7 @@ public:
 	const char* getId() const { return id.c_str(); }
 	VehicleController getController() { return ctrl; }
 	const glm::vec4& getColor() const { return color; }
-	glm::vec3 getForward() const { return position + 2.f*direction; }
+	glm::vec3 getForward() const { return position + direction; }
 	const glm::vec3& getPosition() const { return position; }
 	glm::quat getOrientation() const;
 


### PR DESCRIPTION
Vehicle now sits very close (but not right on) the tile plane.

Changed the phsyX vehicle model to have the bottom of the chassis sit half-way up the wheel instead of the car body sit on top of the wheel.  Helps with stability and avoids flipping when turning.

Vehicle graphics model is scaled down and translated down (hard coded in Vehcile::setModelMatrix) to match the physX vehicle models.