### PR TITLE
Construct PickupManager before using and other cleanup.

### DIFF
--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -14,13 +14,14 @@ Engine::Engine() :
 {
 	shader = std::make_shared<openGLHelper::Shader>("rsc/shaders/vertex.glsl", "rsc/shaders/fragment.glsl");
 	shader->link();
+	
 	render::Renderer::getInstance().initShaderUniforms(shader);
+	pickupManager = std::make_unique<entity::PickupManager>();
 
 	// load textures into a shared pointer.
 	loadTextures();
 	initEntities();
 	setupAudioPlayer();
-	pickupManager = std::shared_ptr<entity::PickupManager> (new entity::PickupManager);
 	controller = std::make_unique<Controller>(render::Renderer::getInstance().getWindow(), camera, vehicles[0], menu);
 }
 

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -54,8 +54,7 @@ private:
 	std::shared_ptr<openGLHelper::Texture> background;
 
 	std::shared_ptr<audio::AudioPlayer> audioPlayer;
-	std::shared_ptr<entity::PickupManager> pickupManager;
-	//entity::PickupManager pickupManager;
+	std::unique_ptr<entity::PickupManager> pickupManager;
 
 	float deltaSec;
 	float lastFrame;

--- a/src/entity/PickupManager.cpp
+++ b/src/entity/PickupManager.cpp
@@ -20,12 +20,11 @@ PickupManager::PickupManager() {
 }
 
 PickupManager::~PickupManager() {
-
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
-void PickupManager::setUp(std::shared_ptr<entity::Arena> arena) {
+void PickupManager::setUp(const std::shared_ptr<entity::Arena>& arena) {
 	onArenaPickupLocations.push_back(arena->getTilePos(glm::vec2(3, 3)) + glm::vec3(0.f, 1.f, 0.f));
 	onArenaPickupLocations.push_back(arena->getTilePos(glm::vec2(36, 3)) + glm::vec3(0.f, 1.f, 0.f));
 	onArenaPickupLocations.push_back(arena->getTilePos(glm::vec2(3, 36)) + glm::vec3(0.f, 1.f, 0.f));

--- a/src/entity/PickupManager.h
+++ b/src/entity/PickupManager.h
@@ -13,7 +13,7 @@ public:
 	void setupPickups(int numberOfPickups, std::vector <glm::vec3> startingPositions, const std::shared_ptr<openGLHelper::Shader>& shader);
 	void checkActivePickups();
 	void tearDown();
-	void setUp(std::shared_ptr<entity::Arena> arena);
+	void setUp(const std::shared_ptr<entity::Arena>& arena);
 	std::vector<glm::vec3> onArenaPickupLocations;
 
 	std::vector< std::shared_ptr<Pickup> > onArenaPickups;//pickups to render and search for collisions


### PR DESCRIPTION
* `Engine::initEntities()` was being called, which makes uses of the `PickupManager`, before the `PickupManager` was constructed.
* Clean up:
  * Make `PickupManager` a `unique_ptr` in `Engine`.
  * Have `PickupManager::setUp()` take in a `const` reference to `shared_ptr<Arena>` rather than copying.