### PR TITLE
Render 4 wheels separately.

### DIFF
--- a/rsc/models/wheel.mtl
+++ b/rsc/models/wheel.mtl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7a5c4894ae03d3e84b290b9bb423525016503df7c0f301c3859a957c19aa587
+size 420

--- a/rsc/models/wheel.obj
+++ b/rsc/models/wheel.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a7b36edcaefa500d3ff5029674a96c073caa0de27968ef74a1e8e9e15f3b608
+size 18865

--- a/rsc/models/wheels_front.mtl
+++ b/rsc/models/wheels_front.mtl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db023c0dc91b0b5d056f06cca077ab66f61caf284cf92d3388777cfd0e4aa782
-size 412

--- a/rsc/models/wheels_front.obj
+++ b/rsc/models/wheels_front.obj
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d766b5278e8897664903425df5749c3a865f4dd88477d04f3d7fe76ed069371
-size 52450

--- a/rsc/models/wheels_rear.mtl
+++ b/rsc/models/wheels_rear.mtl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db023c0dc91b0b5d056f06cca077ab66f61caf284cf92d3388777cfd0e4aa782
-size 412

--- a/rsc/models/wheels_rear.obj
+++ b/rsc/models/wheels_rear.obj
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b214296afde6be0f36296fac61286903aad4b362fdd82cfb740e04e9b149c74
-size 52928

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -104,24 +104,24 @@ void Engine::initEntities()
 	renderables.push_back(arena);
 
 	// Create the player vehicle, setting its starting position, direction, and team (which includes the color of the vehicle/tiles)
-	std::shared_ptr<entity::Vehicle> player = std::make_shared<entity::Vehicle>("player", teamStats::Teams::TEAM0, shader, arena->getTilePos(playerStartingPosition) + glm::vec3(0, 1.f ,0), glm::vec3(1.f, 0.f, 0.f));
+	std::shared_ptr<entity::Vehicle> player = std::make_shared<entity::Vehicle>(teamStats::Teams::TEAM0, shader, arena->getTilePos(playerStartingPosition) + glm::vec3(0, 1.f ,0), glm::vec3(1.f, 0.f, 0.f));
 	vehicles.push_back(player);
 	renderables.push_back(std::static_pointer_cast<render::Renderer::IRenderable>(player));
 	physicsModels.push_back(std::static_pointer_cast<physics::IPhysical>(player));
 	
 	// Create the 4 ai vehicles, setting their starting position, direction, and team (which includes the color of the vehicle/tiles)
 	
-	std::shared_ptr<entity::Vehicle> ai1 = std::make_shared<entity::Vehicle>("ai1", teamStats::Teams::TEAM1, shader, arena->getTilePos(ai1StartingPosition) + glm::vec3(0, 1.f, 0), glm::vec3(0.f, 0.f, -1.f));
+	std::shared_ptr<entity::Vehicle> ai1 = std::make_shared<entity::Vehicle>(teamStats::Teams::TEAM1, shader, arena->getTilePos(ai1StartingPosition) + glm::vec3(0, 1.f, 0), glm::vec3(0.f, 0.f, -1.f));
 	vehicles.push_back(ai1);
 	renderables.push_back(std::static_pointer_cast<render::Renderer::IRenderable>(ai1));
 	physicsModels.push_back(std::static_pointer_cast<physics::IPhysical>(ai1));
 
-	std::shared_ptr<entity::Vehicle> ai2 = std::make_shared<entity::Vehicle>("ai2", teamStats::Teams::TEAM2, shader, arena->getTilePos(ai2StartingPosition) + glm::vec3(0, 1.f, 0), glm::vec3(0.f, 0.f, -1.f));
+	std::shared_ptr<entity::Vehicle> ai2 = std::make_shared<entity::Vehicle>(teamStats::Teams::TEAM2, shader, arena->getTilePos(ai2StartingPosition) + glm::vec3(0, 1.f, 0), glm::vec3(0.f, 0.f, -1.f));
 	vehicles.push_back(ai2);
 	renderables.push_back(std::static_pointer_cast<render::Renderer::IRenderable>(ai2));
 	physicsModels.push_back(std::static_pointer_cast<physics::IPhysical>(ai2));
 
-	std::shared_ptr<entity::Vehicle> ai3 = std::make_shared<entity::Vehicle>("ai3", teamStats::Teams::TEAM3, shader, arena->getTilePos(ai3StartingPosition) + glm::vec3(0, 1.f, 0), glm::vec3(0.f, 0.f, -1.f));
+	std::shared_ptr<entity::Vehicle> ai3 = std::make_shared<entity::Vehicle>(teamStats::Teams::TEAM3, shader, arena->getTilePos(ai3StartingPosition) + glm::vec3(0, 1.f, 0), glm::vec3(0.f, 0.f, -1.f));
 	vehicles.push_back(ai3);
 	renderables.push_back(std::static_pointer_cast<render::Renderer::IRenderable>(ai3));
 	physicsModels.push_back(std::static_pointer_cast<physics::IPhysical>(ai3));

--- a/src/entity/Vehicle.cpp
+++ b/src/entity/Vehicle.cpp
@@ -19,8 +19,7 @@ Vehicle::Vehicle(const std::string& _id,
 	position(startPos), direction(normalize(startDir)), startDirection(startDir)
 {
 	string bodyIdSuffix = "body";
-	string wheelsFrontIdSuffix = "wheelsfront";
-	string wheelsRearIdSuffix = "wheelsRear";
+	string wheelsIdSuffix = "wheel";
 
 	if (id ==  "player") {
 		ctrl.contrId = 0;
@@ -65,8 +64,7 @@ Vehicle::Vehicle(const std::string& _id,
 		index++;
 	}
 
-	wheelsFront = std::make_unique<model::Model>("rsc/models/wheels_front.obj", id + wheelsFrontIdSuffix, _shader, nullptr);
-	wheelsRear = std::make_unique<model::Model>("rsc/models/wheels_rear.obj", id + wheelsRearIdSuffix, _shader, nullptr);
+	wheel = std::make_unique<model::Model>("rsc/models/wheel.obj", id + wheelsIdSuffix, _shader, nullptr);
 }
 
 void Vehicle::updatePositionAndDirection() {
@@ -89,8 +87,7 @@ void Vehicle::reset() {
 void Vehicle::render() const
 {
 	body->render();
-	wheelsFront->render();
-	wheelsRear->render();
+	wheel->render();
 }
 
 quat Vehicle::getOrientation() const
@@ -191,22 +188,21 @@ void Vehicle::setModelMatrix(const glm::mat4& modelMat)
 {
 	// Probably a better way to do this, but this is fine for now.
 	float scale = 1 / 3.f; // this must match physX vehicle description in Simulate.cpp - initVehicleDesc()
-	glm::vec3 translate(0.f, -1.8f, 0.f);
+	glm::vec3 translate(0.f, -2.0f, 0.f);
 
 	glm::mat4 final_transform = modelMat;
 	final_transform = glm::scale(modelMat, glm::vec3(scale));
 	final_transform = glm::translate(final_transform, translate);
 	body->setModelMatrix(final_transform);
-	wheelsFront->setModelMatrix(final_transform);
-	wheelsRear->setModelMatrix(final_transform);
+
+	wheel->setModelMatrix(glm::translate(final_transform, glm::vec3(1.5f, 0.51f, 3.0f)));
 }
 
 void Vehicle::setPosition(const glm::vec3& position)
 {
 	this->position = position;
 	body->setPosition(position);
-	wheelsFront->setPosition(position);
-	wheelsRear->setPosition(position);
+	wheel->setPosition(position);
 }
 
 void Vehicle::setBodyMaterial(const model::Material& material)

--- a/src/entity/Vehicle.cpp
+++ b/src/entity/Vehicle.cpp
@@ -8,36 +8,40 @@ namespace entity {
 
 using namespace std;
 using namespace glm;
+using namespace engine;
 
-Vehicle::Vehicle(const std::string& _id,
-	engine::teamStats::Teams team,
+Vehicle::Vehicle(
+	teamStats::Teams team,
 	const std::shared_ptr<openGLHelper::Shader>& shader,
 	vec3 startPos,
 	vec3 startDir = vec3(0.0f, 0.0f, -1.0f))
 	:IRenderable(shader),
-	id(_id), team(team), color(engine::teamStats::colors.at(team)),
+	team(team), color(teamStats::colors.at(team)),
 	position(startPos), direction(normalize(startDir)), startDirection(startDir)
 {
 	string bodyIdSuffix = "body";
 	string wheelsIdSuffix = "wheel";
 
-	if (id ==  "player") {
+	switch (team)
+	{
+	case teamStats::Teams::TEAM0:
 		ctrl.contrId = 0;
-	}
-	else if (id == "ai1") {
+		break;
+	case teamStats::Teams::TEAM1:
 		ctrl.contrId = 1;
-	}
-	else if (id == "ai2") {
+		break;
+	case teamStats::Teams::TEAM2:
 		ctrl.contrId = 2;
-	}
-	else if (id == "ai3") {
+		break;
+	case teamStats::Teams::TEAM3:
 		ctrl.contrId = 3;
-	}
-	else {
+		break;
+	default:
 		cout << "unknown vehicle name. see vehicle constructor" << endl;
+		break;
 	}
 
-	body = std::make_unique<model::Model>("rsc/models/car_body.obj", id + bodyIdSuffix, _shader, nullptr);
+	body = std::make_unique<model::Model>("rsc/models/car_body.obj", teamStats::names[team] + bodyIdSuffix, _shader, nullptr);
 	
 	unsigned int index = 0;
 	for (auto& mesh : body->getMeshes())

--- a/src/entity/Vehicle.cpp
+++ b/src/entity/Vehicle.cpp
@@ -200,7 +200,7 @@ void Vehicle::setModelMatrix(const glm::mat4& modelMat)
 {
 	// Probably a better way to do this, but this is fine for now.
 	float scale = 1 / 3.f; // this must match physX vehicle description in Simulate.cpp - initVehicleDesc()
-	glm::vec3 translate(0.f, -2.0f, 0.f);
+	glm::vec3 translate(0.f, -1.7f, 0.f);
 
 	glm::mat4 final_transform = modelMat;
 	final_transform = glm::scale(modelMat, glm::vec3(scale));
@@ -211,15 +211,12 @@ void Vehicle::setModelMatrix(const glm::mat4& modelMat)
 void Vehicle::setWheelsModelMatrix(const glm::mat4& frontLeft, const glm::mat4& frontRight, const glm::mat4& rearRight, const glm::mat4& rearLeft)
 {
 	glm::mat4 scale = glm::scale(glm::mat4(1.f), glm::vec3(1 / 3.f)); // this must match physX vehicle description in Simulate.cpp - initVehicleDesc()
-	glm::mat4 flTrans = glm::translate(glm::mat4(1.f), glm::vec3(-0.02f, -0.075f, 0.05f));
-	glm::mat4 frTrans = glm::translate(flTrans, glm::vec3(0.f, 0.f, -0.12f));
-	glm::mat4 rearTrans = glm::translate(glm::mat4(1.f), glm::vec3(0.12f, -0.075f, .0f));
 	glm::mat4 flipped = glm::eulerAngleY(glm::radians(180.f));
 
-	wheels[physx::PxVehicleDrive4WWheelOrder::eFRONT_LEFT]->setModelMatrix(flTrans * frontLeft * scale);
-	wheels[physx::PxVehicleDrive4WWheelOrder::eFRONT_RIGHT]->setModelMatrix(frTrans * frontRight * scale * flipped);
-	wheels[physx::PxVehicleDrive4WWheelOrder::eREAR_LEFT]->setModelMatrix(rearTrans * rearLeft * scale);
-	wheels[physx::PxVehicleDrive4WWheelOrder::eREAR_RIGHT]->setModelMatrix(rearTrans * rearRight * scale * flipped);
+	wheels[physx::PxVehicleDrive4WWheelOrder::eFRONT_LEFT]->setModelMatrix(frontLeft * scale);
+	wheels[physx::PxVehicleDrive4WWheelOrder::eFRONT_RIGHT]->setModelMatrix(frontRight * scale * flipped);
+	wheels[physx::PxVehicleDrive4WWheelOrder::eREAR_LEFT]->setModelMatrix(rearLeft * scale);
+	wheels[physx::PxVehicleDrive4WWheelOrder::eREAR_RIGHT]->setModelMatrix(rearRight * scale * flipped);
 }
 
 void Vehicle::setPosition(const glm::vec3& position)

--- a/src/entity/Vehicle.h
+++ b/src/entity/Vehicle.h
@@ -23,7 +23,7 @@ struct VehicleController {
 class Vehicle : public render::Renderer::IRenderable, public physics::IPhysical
 {
 public:
-	Vehicle(const std::string& id,
+	Vehicle(
 		engine::teamStats::Teams team,
 		const std::shared_ptr<openGLHelper::Shader>& shader,
 		glm::vec3 startPos,
@@ -33,7 +33,7 @@ public:
 
 	void updatePositionAndDirection();
 
-	const char* getId() const { return id.c_str(); }
+	const char* getId() const { return engine::teamStats::names[team].c_str(); }
 	VehicleController getController() { return ctrl; }
 	const glm::vec4& getColor() const { return color; }
 	glm::vec3 getForward() const { return position + direction; }

--- a/src/entity/Vehicle.h
+++ b/src/entity/Vehicle.h
@@ -89,8 +89,7 @@ private:
 	VehicleController ctrl;
 
 	std::unique_ptr<model::Model> body;
-	std::unique_ptr<model::Model> wheelsFront;
-	std::unique_ptr<model::Model> wheelsRear;
+	std::unique_ptr<model::Model> wheel;
 	unsigned int bodyIdx;
 	unsigned int brakeLightsIdx;
 };

--- a/src/entity/Vehicle.h
+++ b/src/entity/Vehicle.h
@@ -51,6 +51,7 @@ public:
 	bool enoughEnergy();
 
 	void setModelMatrix(const glm::mat4& modelMat);
+	void setWheelsModelMatrix(const glm::mat4& frontLeft, const glm::mat4& frontRight, const glm::mat4& rearRight, const glm::mat4& rearLeft);
 	void setPosition(const glm::vec3& position);
 	void setColor(const glm::vec4 _color) { color = _color; }
 
@@ -80,7 +81,6 @@ public:
 	void render() const;
 private:
 
-	std::string id;
 	engine::teamStats::Teams team;
 	glm::vec4 color;
 	glm::vec3 direction;
@@ -89,7 +89,8 @@ private:
 	VehicleController ctrl;
 
 	std::unique_ptr<model::Model> body;
-	std::unique_ptr<model::Model> wheel;
+	// Follow the order from physx. Front left, front right, rear left, rear right.
+	std::array<std::unique_ptr<model::Model>, 4> wheels;
 	unsigned int bodyIdx;
 	unsigned int brakeLightsIdx;
 };

--- a/src/physics/Simulate.cpp
+++ b/src/physics/Simulate.cpp
@@ -570,6 +570,28 @@ void Simulate::setModelPose(std::shared_ptr<IPhysical>& model)
 					memcpy(&modelPos, &(boxPose.getPosition()), sizeof(PxVec3));
 					model->setPosition(modelPos);
 
+					// Check if this actor is a vehicle and if so, set its wheels pose.
+					for (const auto& name : engine::teamStats::names)
+					{
+						if (name.second.c_str() == actorName)
+						{
+							entity::Vehicle* vehicle = reinterpret_cast<entity::Vehicle*>(actors[i]->userData);
+
+							PxMat44 frontRight = (PxShapeExt::getGlobalPose(*shapes[0], *actors[i]));
+							PxMat44 frontLeft = (PxShapeExt::getGlobalPose(*shapes[1], *actors[i]));
+							PxMat44 rearRight = (PxShapeExt::getGlobalPose(*shapes[2], *actors[i]));
+							PxMat44 rearLeft = (PxShapeExt::getGlobalPose(*shapes[3], *actors[i]));
+
+							glm::mat4 fr, fl, rr, rl;
+							memcpy(&fr, &frontRight, sizeof(PxMat44));
+							memcpy(&fl, &frontLeft, sizeof(PxMat44));
+							memcpy(&rr, &rearRight, sizeof(PxMat44));
+							memcpy(&rl, &rearLeft, sizeof(PxMat44));
+
+							vehicle->setWheelsModelMatrix(fl, fr, rr, rl);
+							break;
+						}
+					}
 				}
 			}
 		}

--- a/src/physics/Simulate.cpp
+++ b/src/physics/Simulate.cpp
@@ -219,7 +219,7 @@ VehicleDesc initVehicleDesc()
 	//Center of mass offset is 0.65m above the base of the chassis and 0.25m towards the front.
 	const float vehScale = 1 / 3.f;
 	const PxF32 chassisMass = 1000.0f; // default 1500
-	const PxVec3 chassisDims(4.f * vehScale, 2.5f * vehScale, 10.1f * vehScale);
+	const PxVec3 chassisDims(3.7f * vehScale, 2.5f * vehScale, 10.1f * vehScale);
 	const PxVec3 chassisMOI
 	((chassisDims.y * chassisDims.y + chassisDims.z * chassisDims.z) * chassisMass / 12.0f,
 		(chassisDims.x * chassisDims.x + chassisDims.z * chassisDims.z) * 0.8f * chassisMass / 12.0f,

--- a/src/physics/SnippetVehicle4WCreate.cpp
+++ b/src/physics/SnippetVehicle4WCreate.cpp
@@ -252,10 +252,11 @@ PxVehicleDrive4W* createVehicle4W(const VehicleDesc& vehicle4WDesc, PxPhysics* p
 	//Set up the sim data for the wheels.
 	PxVehicleWheelsSimData* wheelsSimData = PxVehicleWheelsSimData::allocate(numWheels);
 	{
-		//Compute the wheel center offsets from the origin.
+		// Compute the wheel center offsets from the origin.
+		// Approximatly line up with obj models wheel wells.
 		PxVec3 wheelCenterActorOffsets[PX_MAX_NB_WHEELS];
-		const PxF32 frontZ = chassisDims.z*0.3f;
-		const PxF32 rearZ = -chassisDims.z*0.3f;
+		const PxF32 frontZ = chassisDims.z*0.295f;
+		const PxF32 rearZ = -chassisDims.z*0.265f;
 		fourwheel::computeWheelCenterActorOffsets4W(frontZ, rearZ, chassisDims, wheelWidth, wheelRadius, numWheels, wheelCenterActorOffsets);
 
 		//Set up the simulation data for all wheels.


### PR DESCRIPTION
* Replaces the `front_wheels.obj` and `rear_wheels.obj` with four instances of `wheel.obj`.
* The new wheels model also has smoother normals.
* For some reason the wheels slip out of the correct position when turning. Might have something to do with the fact that the physx model and our rendered model don't have the same length.