### PR TITLE
Vehicle Boost and Trap functionality

### DIFF
--- a/src/engine/Controller.cpp
+++ b/src/engine/Controller.cpp
@@ -37,12 +37,52 @@ bool aPressed;
 bool dPressed;
 bool shiftPressed;
 float flipTimer = glfwGetTime();
+bool boost;
+bool trap;
 
 void Controller::processInput(float deltaSec)
 {
 	if (mainMenu.getState() == ui::MainMenu::State::ON || pauseMenu.getState() == ui::PauseMenu::State::ON || endMenu.getState() == ui::EndMenu::State::ON) {
 		return;
 	}
+
+	/// temp testing
+	if (glfwGetKey(window, GLFW_KEY_T) == GLFW_PRESS)
+	{
+		if (!boost) {
+			//std::cout << "Up key PRESSED" << std::endl;
+			playerVehicle->applyBoost(200);
+			boost = true;
+		}
+	}
+
+	if (glfwGetKey(window, GLFW_KEY_T) == GLFW_RELEASE)
+	{
+		if (boost) {
+			//std::cout << "Up key PRESSED" << std::endl;
+			playerVehicle->releaseBoost();
+			boost = false;
+		}
+	}
+
+	if (glfwGetKey(window, GLFW_KEY_G) == GLFW_PRESS)
+	{
+		if (!trap) {
+			//std::cout << "Up key PRESSED" << std::endl;
+			playerVehicle->applyTrap();
+			trap = true;
+		}
+	}
+
+	if (glfwGetKey(window, GLFW_KEY_G) == GLFW_RELEASE)
+	{
+		if (trap) {
+			//std::cout << "Up key PRESSED" << std::endl;
+			playerVehicle->releaseTrap();
+			trap = false;
+		}
+	}
+
 
 	////////////////////////////////////////// PLAYER VEHICLE CONTROLS
 

--- a/src/entity/Vehicle.cpp
+++ b/src/entity/Vehicle.cpp
@@ -119,6 +119,12 @@ void Vehicle::render() const
 		wheel->render();
 }
 
+// 0 => do nothing, 1 => left correction, 2 => right correction
+void Vehicle::straighten(int dir)
+{
+	ctrl.straighten = dir;
+}
+
 quat Vehicle::getOrientation() const
 {
 	return quat_cast(lookAt(vec3(0.f), direction, up));
@@ -161,6 +167,27 @@ void Vehicle::activatePickup()
 void Vehicle::applyFlipImpulse()
 {
 	ctrl.flipImpulse = true;
+}
+
+void Vehicle::applyBoost(int duration)
+{
+	ctrl.boost.first = duration;
+	ctrl.boost.second = true;
+}
+
+void Vehicle::releaseBoost()
+{
+	ctrl.boost.second = false;
+}
+
+void Vehicle::applyTrap()
+{
+	ctrl.trapped = true;
+}
+
+void Vehicle::releaseTrap()
+{
+	ctrl.trapped = false;
 }
 
 void Vehicle::accelerateForward()
@@ -229,11 +256,13 @@ void Vehicle::stopBrake()
 void Vehicle::stopLeft()
 {
 	ctrl.input[3] = 0;
+	straighten(2);
 }
 
 void Vehicle::stopRight()
 {
 	ctrl.input[2] = 0;
+	straighten(1);
 }
 
 void Vehicle::stopHardTurn() 

--- a/src/entity/Vehicle.h
+++ b/src/entity/Vehicle.h
@@ -18,9 +18,13 @@ namespace entity {
 
 struct VehicleController {
 	int contrId;
+	/*input[6] = { forward, reverse, right, left, handbrake, brake }*/
 	int input[6] = { 0,0,0,0,0,0 };
 	bool flipImpulse = false;
-	// input controls { accelerate, reverse, turn right, turn left, hard turn, brake }
+	std::pair<int, bool> boost = std::make_pair(0, false);
+	bool trapped = false;
+	// straighten: 0 => do nothing, 1 => left correction, 2 => right correction
+	int straighten = 0;
 };
 
 class Vehicle : public render::Renderer::IRenderable, public physics::IPhysical
@@ -60,6 +64,12 @@ public:
 	void equipPickup(std::shared_ptr<Pickup> pickup);
 	void activatePickup();
 	void applyFlipImpulse();
+
+	void applyBoost(int duration);
+	void releaseBoost();
+
+	void applyTrap();
+	void releaseTrap();
 
 	void setModelMatrix(const glm::mat4& modelMat);
 	void setWheelsModelMatrix(const glm::mat4& frontLeft, const glm::mat4& frontRight, const glm::mat4& rearRight, const glm::mat4& rearLeft);
@@ -116,6 +126,7 @@ private:
 	unsigned int brakeLightsIdx;
 	glm::vec4 brakeLightsColor;
 	glm::vec4 reverseLightsColor;
+	void straighten(int dir);
 };
 }	// namespace entity
 }	// namespace hyperbright

--- a/src/physics/Simulate.h
+++ b/src/physics/Simulate.h
@@ -57,8 +57,11 @@ void startTurnHardLeftMode(int v);
 void startTurnHardRightMode(int v);
 void startHandbrakeTurnLeftMode(int v);
 void startHandbrakeTurnRightMode(int v);
+void releaseTurn(int dir, int v);
 void releaseAllControls(int v);
 void applyVehicleFlipImpulse(int v);
+void applyVehicleBoost(int v);
+void applyVehicleTrap(int v);
 }	// namespace Driving
 }	// namespace physics
 }	// namespace hyperbright

--- a/src/physics/SnippetVehicle4WCreate.cpp
+++ b/src/physics/SnippetVehicle4WCreate.cpp
@@ -85,8 +85,8 @@ void setupWheelsSimulationData
 		wheels[PxVehicleDrive4WWheelOrder::eREAR_LEFT].mMaxHandBrakeTorque=3000.0f;
 		wheels[PxVehicleDrive4WWheelOrder::eREAR_RIGHT].mMaxHandBrakeTorque=3000.0f;
 		//Enable steering for the front wheels only.
-		wheels[PxVehicleDrive4WWheelOrder::eFRONT_LEFT].mMaxSteer=PxPi*0.3f;
-		wheels[PxVehicleDrive4WWheelOrder::eFRONT_RIGHT].mMaxSteer=PxPi*0.3f;
+		wheels[PxVehicleDrive4WWheelOrder::eFRONT_LEFT].mMaxSteer=PxPi*0.24f;
+		wheels[PxVehicleDrive4WWheelOrder::eFRONT_RIGHT].mMaxSteer=PxPi*0.24f;
 	}
 
 	//Set up the tires.
@@ -120,7 +120,7 @@ void setupWheelsSimulationData
 		{
 			suspensions[i].mMaxCompression = 0.3f;
 			suspensions[i].mMaxDroop = 0.1f;
-			suspensions[i].mSpringStrength = 35000.0f;	
+			suspensions[i].mSpringStrength = 65000.0f;	
 			suspensions[i].mSpringDamperRate = 4500.0f;
 			suspensions[i].mSprungMass = suspSprungMasses[i];
 		}
@@ -192,12 +192,12 @@ void setupWheelsSimulationData
 	PxVehicleAntiRollBarData barFront;
 	barFront.mWheel0 = PxVehicleDrive4WWheelOrder::eFRONT_LEFT;
 	barFront.mWheel1 = PxVehicleDrive4WWheelOrder::eFRONT_RIGHT;
-	barFront.mStiffness = 50000.0f;
+	barFront.mStiffness = 70000.0f;
 	wheelsSimData->addAntiRollBarData(barFront);
 	PxVehicleAntiRollBarData barRear;
 	barRear.mWheel0 = PxVehicleDrive4WWheelOrder::eREAR_LEFT;
 	barRear.mWheel1 = PxVehicleDrive4WWheelOrder::eREAR_RIGHT;
-	barRear.mStiffness = 65000.0f;
+	barRear.mStiffness = 75000.0f;
 	wheelsSimData->addAntiRollBarData(barRear);
 }
 

--- a/src/physics/SnippetVehicleTireFriction.cpp
+++ b/src/physics/SnippetVehicleTireFriction.cpp
@@ -40,7 +40,7 @@ using namespace physx;
 static PxF32 gTireFrictionMultipliers[MAX_NUM_SURFACE_TYPES][MAX_NUM_TIRE_TYPES]=
 {
 	//NORMAL,	WORN
-	{3.00f,		0.1f}
+	{4.0f,		0.1f}
 };
 
 PxVehicleDrivableSurfaceToTireFrictionPairs* createFrictionPairs(const PxMaterial* defaultMaterial)


### PR DESCRIPTION
Vehicle now has boost functions.  Applying the boost takes a duration in frames per second.  Boost can be released and applied later if boost duration remains.
Vehicle is boosted to a hard-coded max speed that can be adjusted.

Vehicle now has trap functions that slow it down (as if in a slow trap).
Applies a strong force backwards on the vehicle to keep in under a minimum speed.
Min speed is hard-coded and can be adjusted.

For testing purposes you can use T to trigger boost and G to trigger trap.