### PR TITLE
Change tile colors for syphons and traps.

### DIFF
--- a/src/entity/Arena.cpp
+++ b/src/entity/Arena.cpp
@@ -39,7 +39,8 @@ bool Arena::Tile::hasChargingStation() const { return _hasChargingStation; }
 
 Arena::Arena(size_t rows, size_t cols, const std::shared_ptr<openGLHelper::Shader>& shader, float tileScale) : IRenderable(shader),
 	tileModelMatrices( std::make_shared<std::vector<glm::mat4>>( rows * cols, glm::mat4(1.f) )),
-	tileColors( std::make_shared<std::vector<glm::vec4>>(rows * cols, glm::vec4(.3f, .3f, .3f, 1.f)) ),
+	tileBaseColor(.3f, .3f, .3f, 1.f),
+	tileColors( std::make_shared<std::vector<glm::vec4>>(rows * cols, tileBaseColor) ),
 	tileGrid(rows), tileScale(tileScale), tileCollisionRadius(0.5f)
 {
 
@@ -129,9 +130,10 @@ std::optional<glm::vec2> Arena::isOnTile(const glm::vec3& coords) const
 	return glm::vec2(row, col);
 }
 
-void Arena::setTileTeam(const glm::vec2& tileCoords, engine::teamStats::Teams team)
+void Arena::setTileTeam(const glm::vec2& tileCoords, std::optional<engine::teamStats::Teams> team)
 {
-	tileGrid[tileCoords.x][tileCoords.y].setColor(engine::teamStats::colors.at(team));
+	glm::vec4 color = team ? engine::teamStats::colors.at(*team) : tileBaseColor;
+	tileGrid[tileCoords.x][tileCoords.y].setColor(color);
 	tileGrid[tileCoords.x][tileCoords.y].team = team;
 }
 

--- a/src/entity/Arena.cpp
+++ b/src/entity/Arena.cpp
@@ -5,7 +5,7 @@
 namespace hyperbright {
 namespace entity {
 Arena::Tile::Tile(glm::mat4& modelMatrix, glm::vec4& color) :
-	modelMatrix(modelMatrix), color(color), _hasWall(false), _hasChargingStation(false), team(std::nullopt)
+	modelMatrix(modelMatrix), color(color), _hasWall(false), _hasChargingStation(false), isTrap(false), team(std::nullopt)
 {}
 
 void Arena::Tile::translate(const glm::vec3& trans)
@@ -229,6 +229,11 @@ void Arena::addChargingStation(unsigned int col, unsigned int row, Orientation o
 
 void Arena::placeTrap(glm::vec2 tileCoords) {
 	tileGrid[tileCoords.x][tileCoords.y].setTrap();
+
+	// make the color slightly darker
+	glm::vec4 color = tileGrid[tileCoords.x][tileCoords.y].color;
+	color = glm::vec4(glm::vec3(color) * 0.9f, 1.f);
+	tileGrid[tileCoords.x][tileCoords.y].setColor(color);
 }
 
 bool Arena::isTrap(glm::vec2 tileCoords) {
@@ -237,6 +242,13 @@ bool Arena::isTrap(glm::vec2 tileCoords) {
 
 void Arena::removeTrap(glm::vec2 tileCoords) {
 	tileGrid[tileCoords.x][tileCoords.y].removeTrap();
+	
+	// set the color back to the original color.
+	std::optional<engine::teamStats::Teams> team = tileGrid[tileCoords.x][tileCoords.y].team;
+	glm::vec4 color = team ? engine::teamStats::colors.at(*team) : tileBaseColor;
+
+	tileGrid[tileCoords.x][tileCoords.y].setColor(color);
+
 }
 
 void Arena::animateChargingStations(float time)

--- a/src/entity/Arena.h
+++ b/src/entity/Arena.h
@@ -66,12 +66,12 @@ private:
 		bool hasChargingStation() const;
 		void setTrap() { isTrap = true; }
 		void removeTrap() { isTrap = false; }
-		bool isTrap;
 	private:
 		glm::mat4& modelMatrix;
 		glm::vec4& color;
 		bool _hasWall;
 		bool _hasChargingStation;
+		bool isTrap;
 		std::optional<engine::teamStats::Teams> team;	// tile may not have a team.
 	};
 

--- a/src/entity/Arena.h
+++ b/src/entity/Arena.h
@@ -40,7 +40,7 @@ public:
 	glm::vec3 getTilePos(const glm::vec2& coords) const;
 	std::optional<engine::teamStats::Teams> getTeamOnTile(const glm::vec2& coords) const;
 
-	void setTileTeam(const glm::vec2& tileCoords, engine::teamStats::Teams team);
+	void setTileTeam(const glm::vec2& tileCoords, std::optional<engine::teamStats::Teams> team);
 	void addWall(unsigned int col, unsigned int row, unsigned int width, unsigned int length);
 	const WallList& getWalls() const;
 
@@ -78,6 +78,7 @@ private:
 	std::shared_ptr<model::Model> instancedTile;
 	std::shared_ptr<model::Model> instancedTileBorder;
 
+	glm::vec4 tileBaseColor;
 	// Each tile/tile border is instanced, so we need to store all model matrices in one array.
 	model::InstanceModelMatricesPtr tileModelMatrices;
 	model::InstanceColorsPtr tileColors;

--- a/src/physics/Simulate.cpp
+++ b/src/physics/Simulate.cpp
@@ -718,8 +718,16 @@ void Simulate::checkVehiclesOverTile(entity::Arena& arena, const std::vector<std
 				std::cout << "TRAP TRIGGERED\n";
 				arena.removeTrap(vehicle->currentTile);
 			} else if(vehicle->syphonActive){
-			//CHANGE TILE COLOR TO ORIGINAL TILE COLOR
-			//BUMP UP CUR VEHICLE EMERGY
+				std::optional<engine::teamStats::Teams> team = arena.getTeamOnTile(*tileCoords);
+			
+				if (team) {
+					// Decrement the teams score if not the current vehicle colors and remove the team
+					//arena.setTileTeam(*tileCoords, nullopt);
+					//engine::teamStats::scores[*team]--
+				}
+			
+				//CHANGE TILE COLOR TO ORIGINAL TILE COLOR
+				//BUMP UP CUR VEHICLE EMERGY
 			} else if (vehicle->enoughEnergy() && !arena.tileHasChargingStation(*tileCoords))
 			{
 				std::optional<engine::teamStats::Teams> old = arena.getTeamOnTile(*tileCoords);


### PR DESCRIPTION
* For the syphon, add the ability to get which team, if any, is on the tile. Then `Simulate::checkVehicleOverTile()` should notify the `Arena`
* For the trap, the logic to change the color has been implemented in `Arena::setTrap()` and `Arena::removeTrap()`.