### PR TITLE
Add barriers around arena and removed vehicle::straighten()

### DIFF
--- a/src/entity/Vehicle.cpp
+++ b/src/entity/Vehicle.cpp
@@ -126,12 +126,6 @@ void Vehicle::renderShadow(const std::shared_ptr<openGLHelper::Shader>& shadowSh
 		wheel->renderShadow(shadowShader);
 }
 
-// 0 => do nothing, 1 => left correction, 2 => right correction
-void Vehicle::straighten(int dir)
-{
-	ctrl.straighten = dir;
-}
-
 quat Vehicle::getOrientation() const
 {
 	return quat_cast(lookAt(vec3(0.f), direction, up));
@@ -272,13 +266,11 @@ void Vehicle::stopBrake()
 void Vehicle::stopLeft()
 {
 	ctrl.input[3] = 0;
-	straighten(2);
 }
 
 void Vehicle::stopRight()
 {
 	ctrl.input[2] = 0;
-	straighten(1);
 }
 
 void Vehicle::stopHardTurn() 

--- a/src/entity/Vehicle.h
+++ b/src/entity/Vehicle.h
@@ -23,8 +23,6 @@ struct VehicleController {
 	bool flipImpulse = false;
 	std::pair<int, bool> boost = std::make_pair(0, false);
 	std::pair<int, bool> trap = std::make_pair(0, false);
-	// straighten: 0 => do nothing, 1 => left correction, 2 => right correction
-	int straighten = 0;
 };
 
 class Vehicle : public render::IRenderable, public physics::IPhysical

--- a/src/physics/Simulate.cpp
+++ b/src/physics/Simulate.cpp
@@ -153,6 +153,7 @@ void removePickups() {
 Simulate::Simulate(vector<shared_ptr<IPhysical>>& _physicsModels, vector<shared_ptr<entity::Vehicle>>& _vehicles, const entity::Arena& arena, std::shared_ptr<entity::PickupManager>& _pickupManager) :
 	physicsModels(_physicsModels), vehicles(_vehicles)
 {
+	arenaSize = arena.getArenaSize()/2.f * arena.getTileWidth();
 	vehs = &_vehicles;
 	initPhysics();
 	pum = _pickupManager;
@@ -500,13 +501,30 @@ void Simulate::initPhysics()
 
 	//Create a plane to drive on.
 	PxFilterData groundPlaneSimFilterData(COLLISION_FLAG_GROUND, COLLISION_FLAG_GROUND_AGAINST, 0, 0);
-	PxRigidStatic* gGroundPlane = createDrivablePlane(groundPlaneSimFilterData, gMaterial, gPhysics);
+	PxRigidStatic* gGroundPlane = createDrivablePlane(groundPlaneSimFilterData, gMaterial, gPhysics, PxVec3(0, 1, 0), 0.f);
 	
 	// Store nullptr for the userData because we don't ever do anything with the ground.
 	// If we do eventually need to perform some logic on the walls when a collision happens,
 	// then we need to create a Ground class that extends IPhysical and sets the TriggerType to the appropriate value.
 	gGroundPlane->userData = nullptr;
 	gScene->addActor(*gGroundPlane);
+	
+
+	PxRigidStatic* barrier1 = createDrivablePlane(groundPlaneSimFilterData, gMaterial, gPhysics, PxVec3(1, 0, 0), arenaSize.x);
+	barrier1->userData = nullptr;
+	gScene->addActor(*barrier1);
+
+	PxRigidStatic* barrier2 = createDrivablePlane(groundPlaneSimFilterData, gMaterial, gPhysics, PxVec3(-1, 0, 0), arenaSize.x);
+	barrier2->userData = nullptr;
+	gScene->addActor(*barrier2);
+
+	PxRigidStatic* barrier3 = createDrivablePlane(groundPlaneSimFilterData, gMaterial, gPhysics, PxVec3(0, 0, 1), arenaSize.y);
+	barrier3->userData = nullptr;
+	gScene->addActor(*barrier3);
+
+	PxRigidStatic* barrier4 = createDrivablePlane(groundPlaneSimFilterData, gMaterial, gPhysics, PxVec3(0, 0, -1), arenaSize.y);
+	barrier4->userData = nullptr;
+	gScene->addActor(*barrier4);
 
 	//Create Vehicle bodies
 	VehicleDesc vehicleDesc = initVehicleDesc();
@@ -578,18 +596,13 @@ void setDriveMode(entity::VehicleController* ctrl)
 		}
 	}
 	//RIGHT
-	else if (ctrl->input[3]) {
+	if (ctrl->input[3]) {
 		if (ctrl->input[4]) {
 			Driving::startHandbrakeTurnRightMode(vNum);
 		}
 		else {
 			Driving::startTurnHardRightMode(vNum);
 		}
-	}
-	//STRAIGHTEN
-	else if (ctrl->straighten != 0){
-		Driving::releaseTurn(ctrl->straighten, vNum);
-		ctrl->straighten = 0;
 	}
 }
 

--- a/src/physics/Simulate.h
+++ b/src/physics/Simulate.h
@@ -35,7 +35,7 @@ public:
 	void cleanupPhysics();
 private:
 	void initPhysics();
-
+	glm::vec2 arenaSize;
 
 	// physicsModels are all moving/colliding objects in the game including the vehicles
 	// this list is used to update the graphical models with the transforms created by PhysX

--- a/src/physics/SnippetVehicleCreate.cpp
+++ b/src/physics/SnippetVehicleCreate.cpp
@@ -39,10 +39,10 @@ namespace snippetvehicle
 
 using namespace physx;
 
-PxRigidStatic* createDrivablePlane(const PxFilterData& simFilterData, PxMaterial* material, PxPhysics* physics)
+PxRigidStatic* createDrivablePlane(const PxFilterData& simFilterData, PxMaterial* material, PxPhysics* physics, PxVec3 normal, float distance)
 {
 	//Add a plane to the scene.
-	PxRigidStatic* groundPlane = PxCreatePlane(*physics, PxPlane(0,1,0,0), *material);
+	PxRigidStatic* groundPlane = PxCreatePlane(*physics, PxPlane(normal.x, normal.y, normal.z, distance), *material);
 
 	//Get the plane shape so we can set query and simulation filter data.
 	PxShape* shapes[1];

--- a/src/physics/SnippetVehicleCreate.h
+++ b/src/physics/SnippetVehicleCreate.h
@@ -41,7 +41,7 @@ using namespace physx;
 
 ////////////////////////////////////////////////
 
-PxRigidStatic* createDrivablePlane(const PxFilterData& simFilterData, PxMaterial* material, PxPhysics* physics);
+PxRigidStatic* createDrivablePlane(const PxFilterData& simFilterData, PxMaterial* material, PxPhysics* physics, PxVec3 normal, float distance);
 
 ////////////////////////////////////////////////
 


### PR DESCRIPTION
Added parameters to physx createDrivablePlane() to set the planes normal and distance.

Added 4 barriers to the arena using the createDrivablePlane() function.  Distance is gathered from the arena size / 2 times the arenaTileWidth so it should match for any size arena.

Removed experimental function Vehicle::straighten().  Tried to counter-balance hard turns but turning the other way for 1 frame but it ended up making the AI vehicles wobble on straight runs.